### PR TITLE
Bumping article ids as appropriate for 10.10

### DIFF
--- a/ApplePrinterDrivers/CanonLaserPrinterDrivers.download.recipe
+++ b/ApplePrinterDrivers/CanonLaserPrinterDrivers.download.recipe
@@ -19,7 +19,7 @@
             <key>Arguments</key>
             <dict>
                 <key>ARTICLE_NUMBER</key>
-                <string>1648</string>
+                <string>1742</string>
             </dict>
         </dict>
         <dict>

--- a/ApplePrinterDrivers/FujiXeroxPrinterDrivers.download.recipe
+++ b/ApplePrinterDrivers/FujiXeroxPrinterDrivers.download.recipe
@@ -19,7 +19,7 @@
             <key>Arguments</key>
             <dict>
                 <key>ARTICLE_NUMBER</key>
-                <string>904</string>
+                <string>1776</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
They changed the support URLs for these two, Epson (also updated recently) still works. Please test in case I was boneheaded!
