### PR TITLE
Add MEGA.munki recipe

### DIFF
--- a/MegaSoftware/MEGA.munki.recipe
+++ b/MegaSoftware/MEGA.munki.recipe
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the current version of MEGA. Imports it into Munki.</string>
+	<key>Identifier</key>
+	<string>com.github.n8felton.munki.MEGA</string>
+	<key>Input</key>
+	<dict>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>apps/MEGA</string>
+		<key>NAME</key>
+		<string>MEGA</string>
+		<key>MUNKI_CATEGORY</key>
+		<string>Math &amp; Science</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>description</key>
+			<string>Sophisticated and user-friendly software suite for analyzing DNA and protein sequence data from species and populations.</string>
+			<key>display_name</key>
+			<string>MEGA</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>category</key>
+			<string>%MUNKI_CATEGORY%</string>
+			<key>developer</key>
+			<string>Sudhir Kumar, Glen Stecher, and Koichiro Tamura</string>
+			<key>unattended_install</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.2.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.hansen-m.download.mega</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/MegaSoftware/README.md
+++ b/MegaSoftware/README.md
@@ -1,0 +1,3 @@
+Check out autopkg/hansen-m-recipes for more MEGA recipes.
+
+https://github.com/autopkg/hansen-m-recipes/tree/master/MegaSoftware


### PR DESCRIPTION
```
$ autopkg run MEGA.munki -v
Processing MEGA.munki...
WARNING: MEGA.munki is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (version): 7.0.14
URLTextSearcher: Found matching text (build): 7160126
URLTextSearcher: Found matching text (match): 7160126
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.MEGA/downloads/MEGA.dmg
EndOfCheckPhase
MunkiImporter
MunkiImporter: Copied pkginfo to /munki/pkgsinfo/apps/MEGA/MEGA-7.0.14.plist
MunkiImporter: Copied pkg to /munki/pkgs/apps/MEGA/MEGA-7.0.14.dmg
Receipt written to /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.MEGA/receipts/MEGA-receipt-20160812-220625.plist

The following new items were imported into Munki:
    Name  Version  Catalogs  Pkginfo Path                 Pkg Repo Path
    ----  -------  --------  ------------                 -------------
    MEGA  7.0.14   testing   apps/MEGA/MEGA-7.0.14.plist  apps/MEGA/MEGA-7.0.14.dmg
```