### PR TITLE
Add MinitabExpressMU.munki recipe

### DIFF
--- a/MinitabExpressMU/MinitabExpressMU.munki.recipe
+++ b/MinitabExpressMU/MinitabExpressMU.munki.recipe
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest Minitab Express pkg, then imports into Munki along with a postinstall script to set the license server.</string>
+	<key>Identifier</key>
+	<string>com.github.n8felton.munki.MinitabExpressMU</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>MinitabExpress</string>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>apps/MinitabExpress</string>
+		<key>MT_LICENSE_SERVER</key>
+		<string></string>
+		<key>MUNKI_CATEGORY</key>
+		<string>Math &amp; Science</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>description</key>
+			<string>Minitab Express is a lightweight and intuitive statistics package that allows its users to use a range of Minitab tools for introductory statistics. Since Minitab Express emphasizes introductory statistics, it has a more focused range of tools than Minitab.</string>
+			<key>display_name</key>
+			<string>Minitab Express</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>category</key>
+			<string>%MUNKI_CATEGORY%</string>
+			<key>developer</key>
+			<string>Minitab Inc.</string>
+			<key>postinstall_script</key>
+			<string>
+#!/bin/bash
+/bin/cat &gt; '/Library/Application Support/Minitab/Minitab Express/mtblic.conf' &lt;&lt; 'mtblic'
+License File=%MT_LICENSE_SERVER%
+LicenseType=MU
+mtblic
+
+chmod 666 '/Library/Application Support/Minitab/Minitab Express/mtblic.conf'
+			</string>
+		</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.2.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.hansen-m.download.MinitabExpressMU</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/MinitabExpressMU/MinitabExpressMU.munki.recipe
+++ b/MinitabExpressMU/MinitabExpressMU.munki.recipe
@@ -12,8 +12,6 @@
 		<string>MinitabExpress</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/MinitabExpress</string>
-		<key>MT_LICENSE_SERVER</key>
-		<string></string>
 		<key>MUNKI_CATEGORY</key>
 		<string>Math &amp; Science</string>
 		<key>pkginfo</key>
@@ -32,16 +30,6 @@
 			<string>%MUNKI_CATEGORY%</string>
 			<key>developer</key>
 			<string>Minitab Inc.</string>
-			<key>postinstall_script</key>
-			<string>
-#!/bin/bash
-/bin/cat &gt; '/Library/Application Support/Minitab/Minitab Express/mtblic.conf' &lt;&lt; 'mtblic'
-License File=%MT_LICENSE_SERVER%
-LicenseType=MU
-mtblic
-
-chmod 666 '/Library/Application Support/Minitab/Minitab Express/mtblic.conf'
-			</string>
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>

--- a/MinitabExpressMU/README.md
+++ b/MinitabExpressMU/README.md
@@ -1,7 +1,0 @@
-##MinitabExpressMU.munki
-
-This recipe is for Minitab Express used with a Multi-User (MU) license.
-
-To use this recipe you will either need to populate `MT_LICENSE_SERVER` in one of two ways:
-  1. Create an override by running `autopkg make-override MinitabExpressMU.munki` and populate `MT_LICENSE_SERVER` in the override
-  2. Pass it as a key when running the recipe, i.e., `autopkg run MinitabExpressMU.munki --key "MT_LICENSE_SERVER=27000@license.example.com"`

--- a/MinitabExpressMU/README.md
+++ b/MinitabExpressMU/README.md
@@ -1,0 +1,7 @@
+##MinitabExpressMU.munki
+
+This recipe is for Minitab Express used with a Multi-User (MU) license.
+
+To use this recipe you will either need to populate `MT_LICENSE_SERVER` in one of two ways:
+  1. Create an override by running `autopkg make-override MinitabExpressMU.munki` and populate `MT_LICENSE_SERVER` in the override
+  2. Pass it as a key when running the recipe, i.e., `autopkg run MinitabExpressMU.munki --key "MT_LICENSE_SERVER=27000@license.example.com"`


### PR DESCRIPTION
Created a Munki recipe for Minitab Express. Using `MT_LICENSE_SERVER` for setting licensing info.
```
$ autopkg run MinitabExpressMU.munki.recipe --key MT_LICENSE_SERVER="27000@license.example.com" -v
Processing MinitabExpressMU.munki.recipe...
WARNING: MinitabExpressMU.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (url): http://fs1.minitab.com/prodinstalls/minitabexpress/minitabexpress1/1.5.0.0/mac/multi-user/Minitab_Express_MU_v1.5.0.pkg
URLTextSearcher: Found matching text (version): 1.5.0.0
URLTextSearcher: Found matching text (match): http://fs1.minitab.com/prodinstalls/minitabexpress/minitabexpress1/1.5.0.0/mac/multi-user/Minitab_Express_MU_v1.5.0.pkg
URLDownloader
URLDownloader: Storing new Last-Modified header: Fri, 13 May 2016 16:24:13 GMT
URLDownloader: Storing new ETag header: "368ba6c-5735ffad-5ed9b485426dfe4d"
URLDownloader: Downloaded /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.MinitabExpressMU/downloads/Minitab_Express_MU_v1.5.0.pkg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Minitab_Express_MU_v1.5.0.pkg":
CodeSignatureVerifier:    Status: signed by a certificate trusted by Mac OS X
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Minitab, Inc. (3FXKQL2RC3)
CodeSignatureVerifier:        SHA1 fingerprint: C8 83 D0 C0 09 66 AE 6E E8 91 B1 78 EF F5 8C 7D CB BE 42 8D
CodeSignatureVerifier:        -----------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        SHA1 fingerprint: 3B 16 6C 3B 7D C4 B7 51 C9 FE 2A FA B9 13 56 41 E3 88 E1 86
CodeSignatureVerifier:        -----------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        SHA1 fingerprint: 61 1E 5B 66 2C 59 3A 08 FF 58 D1 4A E2 24 52 D1 98 DF 6C 60
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
MunkiImporter
MunkiImporter: Copied pkginfo to /munki/pkgsinfo/apps/MinitabExpress/MinitabExpress-1.5.plist
MunkiImporter: Copied pkg to /munki/pkgs/apps/MinitabExpress/Minitab_Express_MU_v1.5.0-1.5.pkg
Receipt written to /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.MinitabExpressMU/receipts/MinitabExpressMU.munki-receipt-20160813-152743.plist

The following new items were imported into Munki:
    Name            Version  Catalogs  Pkginfo Path                                  Pkg Repo Path                             
    ----            -------  --------  ------------                                  -------------                             
    MinitabExpress  1.5      testing   apps/MinitabExpress/MinitabExpress-1.5.plist  apps/MinitabExpress/Minitab_Express_MU_v1.5.0-1.5.pkg

The following new items were downloaded:
    Download Path                                                                                                              
    -------------                                                                                                              
    /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.MinitabExpressMU/downloads/Minitab_Express_MU_v1.5.0.pkg
```