### PR TITLE
Add Cn3D download and munki recipes

### DIFF
--- a/Cn3D/Cn3D.download.recipe
+++ b/Cn3D/Cn3D.download.recipe
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of Cn3D.</string>
+	<key>Identifier</key>
+	<string>com.github.n8felton.download.Cn3D</string>
+	<key>Input</key>
+	<dict>
+		<key>BASE_URL</key>
+		<string>http://www.ncbi.nlm.nih.gov/Structure/CN3D/cn3dmac.shtml</string>
+		<key>SEARCH_PATTERN</key>
+		<string>(?P&lt;match&gt;ftp://ftp.ncbi.nlm.nih.gov/cn3d/Cn3D-(?P&lt;version&gt;[^-]+)-OSX.zip)</string>
+		<key>NAME</key>
+		<string>Cn3D</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.6.1</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%BASE_URL%</string>
+				<key>re_pattern</key>
+				<string>%SEARCH_PATTERN%</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%match%</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>archive_path</key>
+				<string>%pathname%</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+			<key>Processor</key>
+			<string>Unarchiver</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Cn3D/Cn3D.munki.recipe
+++ b/Cn3D/Cn3D.munki.recipe
@@ -32,6 +32,10 @@
 			<string>%MUNKI_CATEGORY%</string>
 			<key>unattended_install</key>
 			<true/>
+			<key>requires</key>
+			<array>
+				<string>XQuartz</string>
+			</array>
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>

--- a/Cn3D/Cn3D.munki.recipe
+++ b/Cn3D/Cn3D.munki.recipe
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of Cn3D and imports it into Munki.</string>
+	<key>Identifier</key>
+	<string>com.github.n8felton.munki.Cn3D</string>
+	<key>Input</key>
+	<dict>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>apps/%NAME%</string>
+		<key>NAME</key>
+		<string>Cn3D</string>
+		<key>MUNKI_CATEGORY</key>
+		<string>Math &amp; Science</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>description</key>
+			<string>Cn3D ("see in 3D") is a macromolecular structure viewer that allows you to view 3-dimensional structures from NCBI's Entrez Structure database. Cn3D simultaneously displays structure, sequence, and alignment, and now has powerful annotation and alignment editing features.</string>
+			<key>developer</key>
+			<string>United States National Library of Medicine</string>
+			<key>display_name</key>
+			<string>Cn3D</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>category</key>
+			<string>%MUNKI_CATEGORY%</string>
+			<key>unattended_install</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.6.1</string>
+	<key>ParentRecipe</key>
+	<string>com.github.n8felton.download.Cn3D</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pattern</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+			</dict>
+			<key>Processor</key>
+			<string>FileFinder</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>dmg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+				<key>dmg_root</key>
+				<string>%found_filename%</string>
+			</dict>
+			<key>Processor</key>
+			<string>DmgCreator</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%dmg_path%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
```
$ autopkg run Cn3D.munki.recipe -v
Processing Cn3D.munki.recipe...
WARNING: Cn3D.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (version): 4.3.1
URLTextSearcher: Found matching text (match): ftp://ftp.ncbi.nlm.nih.gov/cn3d/Cn3D-4.3.1-OSX.zip
URLDownloader
URLDownloader: Downloaded /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.Cn3D/downloads/Cn3D-4.3.1-OSX.zip
EndOfCheckPhase
Unarchiver
Unarchiver: Guessed archive format 'zip' from filename Cn3D-4.3.1-OSX.zip
Unarchiver: Unarchived /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.Cn3D/downloads/Cn3D-4.3.1-OSX.zip to /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.Cn3D/Cn3D
FileFinder
FileFinder: Found file match: /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.Cn3D/Cn3D/Cn3D.app
DmgCreator
DmgCreator: Created dmg from /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.Cn3D/Cn3D/Cn3D.app at /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.Cn3D/Cn3D.dmg
MunkiImporter
MunkiImporter: Copied pkginfo to /munki/pkgsinfo/apps/Cn3D/Cn3D-4.3.1.plist
MunkiImporter: Copied pkg to /munki/pkgs/apps/Cn3D/Cn3D-4.3.1.dmg
Receipt written to /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.Cn3D/receipts/Cn3D.munki-receipt-20160816-121213.plist

The following new items were imported into Munki:
    Name  Version  Catalogs  Pkginfo Path                Pkg Repo Path
    ----  -------  --------  ------------                -------------
    Cn3D  4.3.1    testing   apps/Cn3D/Cn3D-4.3.1.plist  apps/Cn3D/Cn3D-4.3.1.dmg

The following new items were downloaded:
    Download Path
    -------------
    /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.Cn3D/downloads/Cn3D-4.3.1-OSX.zip
```
