### PR TITLE
Add recipes for Weka

### DIFF
--- a/Weka/Weka.download.recipe
+++ b/Weka/Weka.download.recipe
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of Weka.</string>
+	<key>Identifier</key>
+	<string>com.github.n8felton.download.Weka</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>Weka</string>
+		<key>DOWNLOAD_URL</key>
+		<string>https://sourceforge.net/projects/weka/files/latest/download</string>
+		<key>USER_AGENT</key>
+		<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.4.0</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%DOWNLOAD_URL%</string>
+				<key>request_headers</key>
+				<dict>
+						<key>user-agent</key>
+						<string>%USER_AGENT%</string>
+				</dict>
+				<key>re_pattern</key>
+				<string>url=([^"]+)"</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%match%</string>
+				<key>filename</key>
+				<string>%NAME%.dmg</string>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Weka/Weka.munki.recipe
+++ b/Weka/Weka.munki.recipe
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of Weka and imports it into Munki.</string>
+	<key>Identifier</key>
+	<string>com.github.n8felton.munki.Weka</string>
+	<key>Input</key>
+	<dict>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>apps/%NAME%</string>
+		<key>NAME</key>
+		<string>Weka</string>
+		<key>MUNKI_CATEGORY</key>
+		<string>Math &amp; Science</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>description</key>
+			<string>Weka is a collection of machine learning algorithms for solving real-world data mining problems. It is written in Java and runs on almost any platform. The algorithms can either be applied directly to a dataset or called from your own Java code.</string>
+			<key>developer</key>
+			<string>University of Waikato</string>
+			<key>display_name</key>
+			<string>Weka</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>category</key>
+			<string>%MUNKI_CATEGORY%</string>
+			<key>unattended_install</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.6.1</string>
+	<key>ParentRecipe</key>
+	<string>com.github.n8felton.download.Weka</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+				<key>munkiimport_appname</key>
+				<string>weka-3-8-0-oracle-jvm.app</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
The SourceForge RSS feed didn't differentiate between "release" and "beta" so using that would result in a 3.9.0 (beta) download instead of 3.8.0 (current release).

Instead, I'm hitting the download page with some headers and grabbing the `<noscript>` download link. 

```
$ autopkg run Weka.munki -v
Processing Weka.munki...
WARNING: Weka.munki is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (match): http://downloads.sourceforge.net/project/weka/weka-3-8/3.8.0/weka-3-8-0-oracle-jvm.dmg?r=&amp;ts=1471482210&amp;use_mirror=heanet
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/cwhits-admin/Library/AutoPkg/Cache/com.github.n8felton.munki.Weka/downloads/Weka.dmg
MunkiImporter
MunkiImporter: Copied pkginfo to /munki/pkgsinfo/apps/Weka/Weka-3.8.0.plist
MunkiImporter: Copied pkg to /munki/pkgs/apps/Weka/Weka-3.8.0.dmg
Receipt written to /Users/cwhits-admin/Library/AutoPkg/Cache/com.github.n8felton.munki.Weka/receipts/Weka-receipt-20160817-210335.plist

The following new items were imported into Munki:
    Name  Version  Catalogs  Pkginfo Path                Pkg Repo Path
    ----  -------  --------  ------------                -------------
    Weka  3.8.0    testing   apps/Weka/Weka-3.8.0.plist  apps/Weka/Weka-3.8.0.dmg
```