### PR TITLE
Add recipes for GraphViz

### DIFF
--- a/GraphViz/GraphViz.download.recipe
+++ b/GraphViz/GraphViz.download.recipe
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of GraphViz.</string>
+	<key>Identifier</key>
+	<string>com.github.n8felton.download.GraphViz</string>
+	<key>Input</key>
+	<dict>
+		<key>BASE_URL</key>
+		<string>http://www.graphviz.org</string>
+		<key>RE_PATTERN</key>
+		<string>&lt;a href=&quot;/(.*mountainlion[^&quot;]+)&quot;</string>
+		<key>NAME</key>
+		<string>GraphViz</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.6.1</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%BASE_URL%/Download_macos.php</string>
+				<key>re_pattern</key>
+				<string>%RE_PATTERN%</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%BASE_URL%/%match%</string>
+				<key>filename</key>
+				<string>%NAME%.pkg</string>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/GraphViz/GraphViz.munki.recipe
+++ b/GraphViz/GraphViz.munki.recipe
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of GraphViz and imports it into Munki.</string>
+	<key>Identifier</key>
+	<string>com.github.n8felton.munki.GraphViz</string>
+	<key>Input</key>
+	<dict>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>apps/%NAME%</string>
+		<key>NAME</key>
+		<string>GraphViz</string>
+		<key>MUNKI_CATEGORY</key>
+		<string>Math &amp; Science</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>description</key>
+			<string>GraphViz (short for Graph Visualization Software) is a package of open-source tools initiated by AT&amp;T Labs Research for drawing graphs specified in DOT language scripts. It also provides libraries for software applications to use the tools. GraphViz is free software licensed under the Eclipse Public License.</string>
+			<key>developer</key>
+			<string>AT&amp;T Labs Research</string>
+			<key>display_name</key>
+			<string>GraphViz</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>category</key>
+			<string>%MUNKI_CATEGORY%</string>
+			<key>unattended_install</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.6.1</string>
+	<key>ParentRecipe</key>
+	<string>com.github.n8felton.download.GraphViz</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Not codesigned.
```
$ pkgutil --check-signature ~/Downloads/graphviz-2.36.0.pkg
Package "graphviz-2.36.0.pkg":
   Status: no signature

```

Recipe output:
```
$ autopkg run GraphViz/GraphViz.munki.recipe -v
Processing GraphViz/GraphViz.munki.recipe...
WARNING: GraphViz/GraphViz.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (match): pub/graphviz/stable/macos/mountainlion/graphviz-2.36.0.pkg
URLDownloader
URLDownloader: Storing new Last-Modified header: Sun, 12 Jan 2014 00:29:04 GMT
URLDownloader: Storing new ETag header: "1c0036-8f8470-4efbb0be01400"
URLDownloader: Downloaded /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.GraphViz/downloads/GraphViz.pkg
MunkiImporter
MunkiImporter: Copied pkginfo to /munki/pkgsinfo/apps/GraphViz/GraphViz-2.36.0.plist
MunkiImporter: Copied pkg to /munki/pkgs/apps/GraphViz/GraphViz-2.36.0.pkg
Receipt written to /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.GraphViz/receipts/GraphViz.munki-receipt-20160819-141255.plist

The following new items were imported into Munki:
    Name      Version  Catalogs  Pkginfo Path                         Pkg Repo Path                   
    ----      -------  --------  ------------                         -------------                   
    GraphViz  2.36.0   testing   apps/GraphViz/GraphViz-2.36.0.plist  apps/GraphViz/GraphViz-2.36.0.pkg

The following new items were downloaded:
    Download Path                                                                                     
    -------------                                                                                     
    /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.GraphViz/downloads/GraphViz.pkg
```