### PR TITLE
Add recipe for Continuum's Anaconda

### DIFF
--- a/Continuum/Anaconda.munki.recipe
+++ b/Continuum/Anaconda.munki.recipe
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of Continuum's Anaconda and imports it into Munki.</string>
+	<key>Identifier</key>
+	<string>com.github.n8felton.munki.Anaconda</string>
+	<key>Input</key>
+	<dict>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>apps/%NAME%</string>
+		<key>NAME</key>
+		<string>Anaconda</string>
+		<key>PYTHON_MAJOR_VERSION</key>
+		<string>2</string>
+		<key>MUNKI_CATEGORY</key>
+		<string>Math &amp; Science</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>description</key>
+			<string>&lt;a href="https://docs.continuum.io/anaconda"&gt;Anaconda&lt;/a&gt; is an easy-to-install free package manager, environment manager, Python distribution, and collection of over 720 open source packages offering free community support. Hundreds more open source packages and their dependencies can be installed with a simple &lt;span style="font-family: Consolas,'Liberation Mono',Courier,monospace;background: #000; color: #fff; padding:.3125rem;"&gt;conda install [packagename]&lt;/span&gt;. It’s platform-agnostic, can be used on Windows, OS X and Linux. Or even easier, with new &lt;a href="https://docs.continuum.io/anaconda/navigator"&gt;Anaconda Navigator&lt;/a&gt; for point and click install of environments and packages!</string>
+			<key>developer</key>
+			<string>Continuum Analytics, Inc.</string>
+			<key>name</key>
+			<string>%NAME%%PYTHON_MAJOR_VERSION%</string>
+			<key>category</key>
+			<string>%MUNKI_CATEGORY%</string>
+			<key>unattended_install</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.5.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.hansen-m.download.Anaconda</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>display_name</key>
+					<string>Anaconda (Python %PYTHON_VERSION% version)</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Continuum/Anaconda.munki.recipe
+++ b/Continuum/Anaconda.munki.recipe
@@ -16,6 +16,8 @@
 		<string>2</string>
 		<key>MUNKI_CATEGORY</key>
 		<string>Math &amp; Science</string>
+		<key>USERS_GROUP</key>
+		<string>MAIN\Domain Users</string>
 		<key>pkginfo</key>
 		<dict>
 			<key>catalogs</key>
@@ -23,7 +25,7 @@
 				<string>testing</string>
 			</array>
 			<key>description</key>
-			<string>&lt;a href="https://docs.continuum.io/anaconda"&gt;Anaconda&lt;/a&gt; is an easy-to-install free package manager, environment manager, Python distribution, and collection of over 720 open source packages offering free community support. Hundreds more open source packages and their dependencies can be installed with a simple &lt;span style="font-family: Consolas,'Liberation Mono',Courier,monospace;background: #000; color: #fff; padding:.3125rem;"&gt;conda install [packagename]&lt;/span&gt;. It’s platform-agnostic, can be used on Windows, OS X and Linux. Or even easier, with new &lt;a href="https://docs.continuum.io/anaconda/navigator"&gt;Anaconda Navigator&lt;/a&gt; for point and click install of environments and packages!</string>
+			<string>&lt;a href="https://docs.continuum.io/anaconda"&gt;Anaconda&lt;/a&gt; is an easy-to-install free package manager, environment manager, Python distribution, and collection of over 720 open source packages offering free community support. Hundreds more open source packages and their dependencies can be installed with a simple &lt;span style="font-family: Consolas,'Liberation Mono',Courier,monospace;background: #eee; color: #f00; padding:.3125rem;"&gt;conda install [packagename]&lt;/span&gt;. It’s platform-agnostic, can be used on Windows, OS X and Linux. Or even easier, with new &lt;a href="https://docs.continuum.io/anaconda/navigator"&gt;Anaconda Navigator&lt;/a&gt; for point and click install of environments and packages!</string>
 			<key>developer</key>
 			<string>Continuum Analytics, Inc.</string>
 			<key>name</key>
@@ -47,6 +49,19 @@
 				<dict>
 					<key>display_name</key>
 					<string>Anaconda (Python %PYTHON_VERSION% version)</string>
+					<key>postinstall_script</key>
+					<string>#!/bin/bash
+ln -s /anaconda/Navigator.app /Applications/
+
+mkdir -p /anaconda/python.app/Contents/lib
+
+ln -s /anaconda/lib/tcl8.5 /anaconda/python.app/Contents/lib/tcl8.5
+ln -s /anaconda/lib/tk8.5 /anaconda/python.app/Contents/lib/tk8.5
+
+echo "/anaconda/bin" &gt; /etc/paths.d/anaconda
+
+chgrp -R "%USERS_GROUP%" /anaconda
+chmod -R g+w /anaconda</string>
 				</dict>
 			</dict>
 			<key>Processor</key>

--- a/Continuum/Anaconda.munki.recipe
+++ b/Continuum/Anaconda.munki.recipe
@@ -14,8 +14,6 @@
 		<string>Anaconda</string>
 		<key>PYTHON_MAJOR_VERSION</key>
 		<string>2</string>
-		<key>MUNKI_CATEGORY</key>
-		<string>Math &amp; Science</string>
 		<key>USERS_GROUP</key>
 		<string>MAIN\Domain Users</string>
 		<key>pkginfo</key>
@@ -31,7 +29,7 @@
 			<key>name</key>
 			<string>%NAME%%PYTHON_MAJOR_VERSION%</string>
 			<key>category</key>
-			<string>%MUNKI_CATEGORY%</string>
+			<string>Math &amp; Science</string>
 			<key>unattended_install</key>
 			<true/>
 		</dict>


### PR DESCRIPTION
 ```
$ autopkg run ./Anaconda.munki.recipe -v -k PYTHON_MAJOR_VERSION=3
Processing ./Anaconda.munki.recipe...
WARNING: ./Anaconda.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (PYTHON_VERSION): 3.5
URLTextSearcher: Found matching text (match): 3.5
URLTextSearcher
URLTextSearcher: Found matching text (url): https://repo.continuum.io/archive/Anaconda3-4.2.0-MacOSX-x86_64.pkg
URLTextSearcher: Found matching text (version): 4.2.0
URLTextSearcher: Found matching text (match): https://repo.continuum.io/archive/Anaconda3-4.2.0-MacOSX-x86_64.pkg
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.Anaconda/downloads/Anaconda3-4.2.0.pkg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Anaconda3-4.2.0.pkg":
CodeSignatureVerifier:    Status: signed by a certificate trusted by Mac OS X
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: CONTINUUM ANALYTICS INC (Z5788K4JT7)
CodeSignatureVerifier:        SHA1 fingerprint: 88 57 F2 81 D2 DC 1A 7E F0 FA F5 2C A0 B3 86 80 D1 70 BA C0
CodeSignatureVerifier:        -----------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        SHA1 fingerprint: 3B 16 6C 3B 7D C4 B7 51 C9 FE 2A FA B9 13 56 41 E3 88 E1 86
CodeSignatureVerifier:        -----------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        SHA1 fingerprint: 61 1E 5B 66 2C 59 3A 08 FF 58 D1 4A E2 24 52 D1 98 DF 6C 60
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {
    "display_name" = "Anaconda (Python 3.5 version)";
    "postinstall_script" = "#!/bin/bash\nln -s /anaconda/Navigator.app /Applications/\n\nmkdir -p /anaconda/python.app/Contents/lib\n\nln -s /anaconda/lib/tcl8.5 /anaconda/python.app/Contents/lib/tcl8.5\nln -s /anaconda/lib/tk8.5 /anaconda/python.app/Contents/lib/tk8.5\n\necho \"/anaconda/bin\" > /etc/paths.d/anaconda\n\nchgrp -R \"MAIN\\Domain Users\" /anaconda\nchmod -R g+w /anaconda";
} into pkginfo
MunkiImporter
MunkiImporter: Copied pkginfo to /munki/pkgsinfo/apps/Anaconda/Anaconda3-4.2.0.plist
MunkiImporter: Copied pkg to /munki/pkgs/apps/Anaconda/Anaconda3-4.2.0.pkg
Receipt written to /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.Anaconda/receipts/Anaconda.munki-receipt-20170112-210153.plist

The following new items were imported into Munki:
    Name       Version  Catalogs  Pkginfo Path                            Pkg Repo Path
    ----       -------  --------  ------------                            -------------
    Anaconda3  4.2.0    testing   apps/Anaconda/Anaconda3-4.2.0.plist  apps/Anaconda/Anaconda3-4.2.0.pkg
```