### PR TITLE
[OpenRefine] Add munki and download recipe

### DIFF
--- a/OpenRefine/OpenRefine.download.recipe
+++ b/OpenRefine/OpenRefine.download.recipe
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the current release of OpenRefine from Github.</string>
+	<key>Identifier</key>
+	<string>com.github.n8felton.download.OpenRefine</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>OpenRefine</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.6.0</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>asset_regex</key>
+				<string>openrefine-mac-.+\.dmg</string>
+				<key>github_repo</key>
+				<string>OpenRefine/OpenRefine</string>
+                <key>include_prereleases</key>
+                <true/>
+			</dict>
+			<key>Processor</key>
+			<string>GitHubReleasesInfoProvider</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/*.app</string>
+                <key>requirement</key>
+                <string>identifier "com.google.refine.Refine" and certificate leaf = H"3324785d3f758d78f729a7424a75447b15364f98"</string>
+                <key>DISABLE_CODE_SIGNATURE_VERIFICATION</key>
+                <true/>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/OpenRefine/OpenRefine.download.recipe
+++ b/OpenRefine/OpenRefine.download.recipe
@@ -22,8 +22,8 @@
 				<string>openrefine-mac-.+\.dmg</string>
 				<key>github_repo</key>
 				<string>OpenRefine/OpenRefine</string>
-                <key>include_prereleases</key>
-                <true/>
+				<key>include_prereleases</key>
+				<true/>
 			</dict>
 			<key>Processor</key>
 			<string>GitHubReleasesInfoProvider</string>
@@ -35,19 +35,6 @@
 		<dict>
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>input_path</key>
-				<string>%pathname%/*.app</string>
-                <key>requirement</key>
-                <string>identifier "com.google.refine.Refine" and certificate leaf = H"3324785d3f758d78f729a7424a75447b15364f98"</string>
-                <key>DISABLE_CODE_SIGNATURE_VERIFICATION</key>
-                <true/>
-			</dict>
-			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
 		</dict>
 	</array>
 </dict>

--- a/OpenRefine/OpenRefine.munki.recipe
+++ b/OpenRefine/OpenRefine.munki.recipe
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of OpenRefine and imports it into Munki.</string>
+    <key>Identifier</key>
+    <string>com.github.n8felton.munki.OpenRefine</string>
+    <key>Input</key>
+    <dict>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/%NAME%</string>
+        <key>NAME</key>
+        <string>OpenRefine</string>
+        <key>MUNKI_CATEGORY</key>
+        <string>Math &amp; Science</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>description</key>
+            <string>OpenRefine (formerly Google Refine) is a powerful tool for working with messy data: cleaning it&#59; transforming it from one format into another; and extending it with web services and external data.</string>
+            <key>developer</key>
+            <string>OpenRefine</string>
+            <key>display_name</key>
+            <string>OpenRefine</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>category</key>
+            <string>%MUNKI_CATEGORY%</string>
+            <key>unattended_install</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.6.1</string>
+    <key>ParentRecipe</key>
+    <string>com.github.n8felton.download.OpenRefine</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
Added a recipe for OpenRefine.

```
$ autopkg run OpenRefine.munki.recipe -v
Processing OpenRefine.munki.recipe...
WARNING: OpenRefine.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
GitHubReleasesInfoProvider: Matched regex 'openrefine-mac-.+\.dmg' among asset(s): openrefine-linux-2.7-rc.1.tar.gz, openrefine-mac-2.7-rc.1.dmg, openrefine-win-2.7-rc.1.zip
GitHubReleasesInfoProvider: Selected asset 'openrefine-mac-2.7-rc.1.dmg' from release 'OpenRefine v2.7 Release Candidate 1'
URLDownloader
URLDownloader: Storing new Last-Modified header: Sat, 11 Feb 2017 14:04:05 GMT
URLDownloader: Storing new ETag header: "58c85126b7419a1fca87d6e0941fe8aa"
URLDownloader: Downloaded /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.OpenRefine/downloads/openrefine-mac-2.7-rc.1.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Code signature verification disabled for this recipe run.
MunkiImporter
MunkiImporter: Copied pkginfo to /munki/pkgsinfo/apps/OpenRefine/OpenRefine-2.7-rc.1.plist
MunkiImporter: Copied pkg to /munki/pkgs/apps/OpenRefine/openrefine-mac-2.7-rc.1.dmg
Receipt written to /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.OpenRefine/receipts/OpenRefine.munki-receipt-20170222-174635.plist

The following new items were imported into Munki:
    Name        Version   Catalogs  Pkginfo Path                               Pkg Repo Path
    ----        -------   --------  ------------                               -------------
    OpenRefine  2.7-rc.1  testing   apps/OpenRefine/OpenRefine-2.7-rc.1.plist  apps/OpenRefine/openrefine-mac-2.7-rc.1.dmg

The following new items were downloaded:
    Download Path
    -------------
    /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.OpenRefine/downloads/openrefine-mac-2.7-rc.1.dmg
```