### PR TITLE
[AdobeConnect] add munki and download recipes

### DIFF
--- a/AdobeConnectAddin/AdobeConnectAddin.download.recipe
+++ b/AdobeConnectAddin/AdobeConnectAddin.download.recipe
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Download recipe for Adobe Connect 9 Meeting Add-in.</string>
+	<key>Identifier</key>
+	<string>com.github.n8felton.adobeconnectaddin.download</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>AdobeConnectAddin</string>
+		<key>DOWNLOAD_URL</key>
+		<string>http://www.adobe.com/go/adobeconnect_9_addin_mac</string>
+	</dict>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%DOWNLOAD_URL%</string>
+				<key>filename</key>
+				<string>%NAME%.zip</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>Unarchiver</string>
+			<key>Arguments</key>
+			<dict>
+				<key>archive_path</key>
+				<string>%pathname%</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+				<key>purge_destionation</key>
+				<true/>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/*.pkg</string>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: Adobe Systems, Inc.</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
+	<key>MinimumVersion</key>
+	<string>0.2.9</string>
+</dict>
+</plist>

--- a/AdobeConnectAddin/AdobeConnectAddin.munki.recipe
+++ b/AdobeConnectAddin/AdobeConnectAddin.munki.recipe
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of the Adobe Connect 9 Meeting Add-in and imports it into Munki.</string>
+	<key>Identifier</key>
+	<string>com.github.n8felton.adobeconnectaddin.munki</string>
+	<key>ParentRecipe</key>
+	<string>com.github.n8felton.adobeconnectaddin.download</string>
+	<key>Input</key>
+	<dict>
+		<key>MUNKI_REPO_SUBDIR</key>
+        <string>plugins/adobe</string>
+		<key>NAME</key>
+		<string>AdobeConnectAddin</string>
+		<key>MUNKI_CATEGORY</key>
+		<string>Plugins</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>description</key>
+			<string>Adobe Connect is used to create information and general presentations, online training materials, web conferencing, learning modules, and user desktop sharing.</string>
+			<key>display_name</key>
+			<string>Adobe Connect 9 Meeting Add-in</string>
+			<key>minimum_os_version</key>
+			<string>10.6.0</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>category</key>
+			<string>%MUNKI_CATEGORY%</string>
+			<key>developer</key>
+			<string>Adobe</string>
+		</dict>
+	</dict>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>FileFinder</string>
+			<key>Arguments</key>
+			<dict>
+				<key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/*.pkg</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%found_filename%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+		</dict>
+	</array>
+	<key>MinimumVersion</key>
+	<string>0.2.9</string>
+</dict>
+</plist>


### PR DESCRIPTION
```
testbox:n8felton-recipes cwhits$ autopkg run AdobeConnectAddin/AdobeConnectAddin.munki -v
Processing AdobeConnectAddin/AdobeConnectAddin.munki...
WARNING: AdobeConnectAddin/AdobeConnectAddin.munki is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Mon, 09 Jan 2017 19:13:52 GMT
URLDownloader: Storing new ETag header: "5e38e402-297a938-545ae2b061c00"
URLDownloader: Downloaded /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.adobeconnectaddin.munki/downloads/AdobeConnectAddin.zip
EndOfCheckPhase
Unarchiver
Unarchiver: Guessed archive format 'zip' from filename AdobeConnectAddin.zip
Unarchiver: Unarchived /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.adobeconnectaddin.munki/downloads/AdobeConnectAddin.zip to /Users/cwhits
/Library/AutoPkg/Cache/com.github.n8felton.adobeconnectaddin.munki/AdobeConnectAddin
CodeSignatureVerifier
CodeSignatureVerifier: Using path '/Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.adobeconnectaddin.munki/AdobeConnectAddin/adobeconnectaddin-installer.pkg' matched from globbed '/Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.adobeconnectaddin.munki/AdobeConnectAddin/*.pkg'.
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "adobeconnectaddin-installer.pkg":
CodeSignatureVerifier:    Status: signed by a certificate trusted by Mac OS X
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Adobe Systems, Inc.
CodeSignatureVerifier:        SHA1 fingerprint: 9D 75 C9 20 01 4A 65 04 94 A7 63 95 E3 91 93 47 04 E8 57 DF
CodeSignatureVerifier:        -----------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        SHA1 fingerprint: 3B 16 6C 3B 7D C4 B7 51 C9 FE 2A FA B9 13 56 41 E3 88 E1 86
CodeSignatureVerifier:        -----------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        SHA1 fingerprint: 61 1E 5B 66 2C 59 3A 08 FF 58 D1 4A E2 24 52 D1 98 DF 6C 60
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FileFinder
FileFinder: Found file match: /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.adobeconnectaddin.munki/AdobeConnectAddin/adobeconnectaddin-installer.pkg
MunkiImporter
MunkiImporter: Copied pkginfo to /munki/pkgsinfo/plugins/adobe/AdobeConnectAddin-11.2.plist
MunkiImporter: Copied pkg to /munki/pkgs/plugins/adobe/adobeconnectaddin-installer-11.2.pkg
Receipt written to /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.adobeconnectaddin.munki/receipts/AdobeConnectAddin-receipt-20170303-135716.plist

The following new items were imported into Munki:
    Name               Version  Catalogs  Pkginfo Path                                Pkg Repo Path
    ----               -------  --------  ------------                                -------------
    AdobeConnectAddin  11.2     testing   plugins/adobe/AdobeConnectAddin-11.2.plist  plugins/adobe/adobeconnectaddin-installer-11.2.pkg

The following new items were downloaded:
    Download Path
    -------------
    /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.adobeconnectaddin.munki/downloads/AdobeConnectAddin.zip
```