### PR TITLE
[SerialCloner] Add munki and download recipes

### DIFF
--- a/SerialCloner/README.md
+++ b/SerialCloner/README.md
@@ -1,0 +1,1 @@
+This recipe uses features in the `FileFinder` processor that are not in the 1.0.1 release of AutoPkg. To use this recipe, you'll need to clone and manually install AutoPkg.

--- a/SerialCloner/SerialCloner.download.recipe
+++ b/SerialCloner/SerialCloner.download.recipe
@@ -41,6 +41,10 @@
 				<string>%NAME%.dmg</string>
 			</dict>
 		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/SerialCloner/SerialCloner.download.recipe
+++ b/SerialCloner/SerialCloner.download.recipe
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of SerialCloner.</string>
+	<key>Identifier</key>
+	<string>com.github.n8felton.download.SerialCloner</string>
+	<key>Input</key>
+	<dict>
+		<key>BASE_URL</key>
+		<string>http://serialbasics.free.fr</string>
+		<key>RE_PATTERN</key>
+		<string>href=&quot;(.*(?P&lt;foldername&gt;SerialCloner.*)\.dmg)&quot;</string>
+		<key>NAME</key>
+		<string>SerialCloner</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.6.1</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%BASE_URL%/Serial_Cloner-Download.html</string>
+				<key>re_pattern</key>
+				<string>%RE_PATTERN%</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%BASE_URL%/%match%</string>
+				<key>filename</key>
+				<string>%NAME%.dmg</string>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/SerialCloner/SerialCloner.munki.recipe
+++ b/SerialCloner/SerialCloner.munki.recipe
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the current release version of SerialCloner and imports it into Munki.
+Note: You will need a version of AutoPkg newer than 1.0.1 to use this recipe.</string>
+	<key>Identifier</key>
+	<string>com.github.n8felton.munki.SerialCloner</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>SerialCloner</string>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>apps/%NAME%</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>description</key>
+			<string>Serial Cloner is a Molecular Biology software. It provides tools with an intuitive interface that assists you in DNA cloning, sequence analysis and visualization.</string>
+			<key>display_name</key>
+			<string>Serial Cloner</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>unattended_install</key>
+			<true/>
+			<key>category</key>
+			<string>Math &amp; Science</string>
+			<key>developer</key>
+			<string>Serial Basics</string>
+			<key>minimum_os_version</key>
+			<string>10.9.5</string>
+		</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.6.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.n8felton.download.SerialCloner</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>FileFinder</string>
+			<key>Arguments</key>
+			<dict>
+				<key>pattern</key>
+				<string>%pathname%/*/*/Contents/*.plist</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>Versioner</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_plist_path</key>
+				<string>%pathname%/%dmg_found_filename%</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+				<key>additional_makepkginfo_options</key>
+				<array>
+					<string>--pkgvers</string>
+					<string>%version%</string>
+					<string>--itemname</string>
+					<string>%foldername%</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Requires a version of AutoPkg newer than 1.0.1.

```$ autopkg run SerialCloner.munki.recipe -v
Processing SerialCloner.munki.recipe...
WARNING: SerialCloner.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (match): Serial_Cloner-Download_files/SerialCloner2-6.dmg
URLTextSearcher: Found matching text (foldername): SerialCloner2-6
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.SerialCloner/downloads/SerialCloner.dmg
FileFinder
FileFinder: Mounted disk image /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.SerialCloner/downloads/SerialCloner.dmg
FileFinder: Found file match: '/private/tmp/dmg.FGUgKK/SerialCloner2-6/SerialCloner 2-6-1.app/Contents/Info.plist' from globbed '/private/tmp/dmg.FGUgKK/*/*/Contents/*.plist'
FileFinder: DMG-relative file match: 'SerialCloner2-6/SerialCloner 2-6-1.app/Contents/Info.plist'
Versioner
Versioner: Mounted disk image /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.SerialCloner/downloads/SerialCloner.dmg
Versioner: Found version 2.6.1 in file /private/tmp/dmg.ys5xMP/SerialCloner2-6/SerialCloner 2-6-1.app/Contents/Info.plist
MunkiImporter
MunkiImporter: Item SerialCloner.dmg already exists in the munki repo as pkgs/apps/SerialCloner/SerialCloner-2.6.1.dmg.
Receipt written to /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.SerialCloner/receipts/SerialCloner.munki-receipt-20170322-164431.plist

Nothing downloaded, packaged or imported.
```