### PR TITLE
[OpenSC] add download and munki recipes

### DIFF
--- a/OpenSC/OpenSC.download.recipe
+++ b/OpenSC/OpenSC.download.recipe
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the current release of OpenSC from Github.</string>
+	<key>Identifier</key>
+	<string>com.github.n8felton.download.OpenSC</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>OpenSC</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.6.0</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>asset_regex</key>
+				<string>OpenSC-.+\.dmg</string>
+				<key>github_repo</key>
+				<string>OpenSC/OpenSC</string>
+				<key>include_prereleases</key>
+				<false/>
+			</dict>
+			<key>Processor</key>
+			<string>GitHubReleasesInfoProvider</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/OpenSC/OpenSC.munki.recipe
+++ b/OpenSC/OpenSC.munki.recipe
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of OpenSC and imports it into Munki.</string>
+	<key>Identifier</key>
+	<string>com.github.n8felton.munki.OpenSC</string>
+	<key>Input</key>
+	<dict>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>apps/%NAME%</string>
+		<key>NAME</key>
+		<string>OpenSC</string>
+		<key>MUNKI_CATEGORY</key>
+		<string>Utilities</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>description</key>
+			<string>OpenSC provides a set of libraries and utilities to work with smart cards. Its main focus is on cards that support cryptographic operations, and facilitate their use in security applications such as authentication, mail encryption and digital signatures. OpenSC implements the PKCS#11 API so applications supporting this API (such as Mozilla Firefox and Thunderbird) can use it.</string>
+			<key>developer</key>
+			<string>OpenSC</string>
+			<key>display_name</key>
+			<string>OpenSC</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>category</key>
+			<string>%MUNKI_CATEGORY%</string>
+			<key>unattended_install</key>
+			<true/>
+			<key>uninstall_method</key>
+			<string>uninstall_script</string>
+			<key>uninstall_script</key>
+			<string>#!/bin/sh
+/usr/local/bin/opensc-uninstall</string>
+		</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.6.1</string>
+	<key>ParentRecipe</key>
+	<string>com.github.n8felton.download.OpenSC</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>source_pkg</key>
+				<string>%pathname%/OpenSC*.pkg</string>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/OpenSC.pkg</string>
+			</dict>
+			<key>Processor</key>
+			<string>PkgCopier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
```
$ autopkg run -v OpenSC/OpenSC.munki.recipe
Processing OpenSC/OpenSC.munki.recipe...
WARNING: OpenSC/OpenSC.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
GitHubReleasesInfoProvider: Matched regex 'OpenSC-.+\.dmg' among asset(s): OpenSC-0.16.0-win32_vs12-Light-Release.msi, OpenSC-0.16.0-win32_vs12-Release.msi, OpenSC-0.16.0-win64_vs12-Light-Release.msi, OpenSC-0.16.0-win64_vs12-Release.msi, OpenSC-0.16.0.dmg, opensc-0.16.0.tar.gz
GitHubReleasesInfoProvider: Selected asset 'OpenSC-0.16.0.dmg' from release 'OpenSC 0.16.0'
URLDownloader
URLDownloader: Storing new Last-Modified header: Fri, 03 Jun 2016 13:39:30 GMT
URLDownloader: Storing new ETag header: "47ae3ae2b805c02abc11414143990c0b"
URLDownloader: Downloaded /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.OpenSC/downloads/OpenSC-0.16.0.dmg
EndOfCheckPhase
PkgCopier
PkgCopier: Mounted disk image /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.OpenSC/downloads/OpenSC-0.16.0.dmg
PkgCopier: Using path '/private/tmp/dmg.Hkq4Qu/OpenSC-0.16.0.pkg' matched from globbed '/private/tmp/dmg.Hkq4Qu/OpenSC*.pkg'.
PkgCopier: Copied /private/tmp/dmg.Hkq4Qu/OpenSC-0.16.0.pkg to /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.OpenSC/OpenSC.pkg
MunkiImporter
MunkiImporter: Copied pkginfo to /Volumes/munki_repo/pkgsinfo/apps/OpenSC/OpenSC-0.16.0.plist
MunkiImporter: Copied pkg to /Volumes/munki_repo/pkgs/apps/OpenSC/OpenSC-0.16.0.pkg
Receipt written to /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.OpenSC/receipts/OpenSC.munki-receipt-20170411-145809.plist

The following packages were copied:
    Pkg Path
    --------
    /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.OpenSC/OpenSC.pkg

The following new items were imported into Munki:
    Name    Version  Catalogs  Pkginfo Path                     Pkg Repo Path
    ----    -------  --------  ------------                     -------------
    OpenSC  0.16.0   testing   apps/OpenSC/OpenSC-0.16.0.plist  apps/OpenSC/OpenSC-0.16.0.pkg

The following new items were downloaded:
    Download Path
    -------------
    /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.OpenSC/downloads/OpenSC-0.16.0.dmg
```

And the uninstall from MSC:
```
Apr 11 2017 11:52:29 -0700 Removing OpenSC (1 of 1)...
Apr 11 2017 11:52:29 -0700     Running uninstall_script for OpenSC
Apr 11 2017 11:52:29 -0700     OpenSC has been removed from your system. See you again!
```