### PR TITLE
NaturalReader

### DIFF
--- a/NaturalReader/NaturalReaderFree.download.recipe
+++ b/NaturalReader/NaturalReaderFree.download.recipe
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest free version of Natural Reader.</string>
+	<key>Identifier</key>
+	<string>com.github.n8felton.download.NaturalReaderFree</string>
+	<key>Input</key>
+	<dict>
+		<key>BASE_URL</key>
+		<string>https://www.naturalreaders.com/download.html</string>
+		<key>RE_PATTERN</key>
+		<string>&lt;a href=&quot;(.*\.pkg)&quot;</string>
+		<key>NAME</key>
+		<string>NaturalReaderFree</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.6.1</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%BASE_URL%</string>
+				<key>re_pattern</key>
+				<string>%RE_PATTERN%</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%match%</string>
+				<key>filename</key>
+				<string>%NAME%.pkg</string>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/NaturalReader/NaturalReaderFree.download.recipe
+++ b/NaturalReader/NaturalReaderFree.download.recipe
@@ -11,7 +11,7 @@
 		<key>BASE_URL</key>
 		<string>https://www.naturalreaders.com/download.html</string>
 		<key>RE_PATTERN</key>
-		<string>&lt;a href=&quot;(.*\.pkg)&quot;</string>
+		<string>&lt;a href=&quot;(.*NaturalReader(?P&lt;version&gt;[0-9\.]*)Free\.pkg)&quot;</string>
 		<key>NAME</key>
 		<string>NaturalReaderFree</string>
 	</dict>

--- a/NaturalReader/NaturalReaderFree.munki.recipe
+++ b/NaturalReader/NaturalReaderFree.munki.recipe
@@ -21,7 +21,7 @@
 				<string>testing</string>
 			</array>
 			<key>description</key>
-			<string>NaturalReader 14 for Mac is a text-to-speech software for Mac and it uses excellent Natural Voices to convert any text into spoken words. It can also convert any written text into audio files for your CD player or iPod.<\br>
+			<string>NaturalReader 14 for Mac is a text-to-speech software for Mac and it uses excellent Natural Voices to convert any text into spoken words. It can also convert any written text into audio files for your CD player or iPod.&lt;br&gt;
 &lt;ul&gt;
 	&lt;li&gt;All basic text to speech functions&lt;/li&gt;
 	&lt;li&gt;Free to download and free to use.&lt;/li&gt;
@@ -51,6 +51,18 @@
 	<string>com.github.n8felton.download.NaturalReaderFree</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/NaturalReader/NaturalReaderFree.munki.recipe
+++ b/NaturalReader/NaturalReaderFree.munki.recipe
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest free version of NaturalReader and imports it into Munki.</string>
+	<key>Identifier</key>
+	<string>com.github.n8felton.munki.NaturalReaderFree</string>
+	<key>Input</key>
+	<dict>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>apps/%NAME%</string>
+		<key>NAME</key>
+		<string>NaturalReaderFree</string>
+		<key>MUNKI_CATEGORY</key>
+		<string>Productivity</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>description</key>
+			<string>NaturalReader 14 for Mac is a text-to-speech software for Mac and it uses excellent Natural Voices to convert any text into spoken words. It can also convert any written text into audio files for your CD player or iPod.<\br>
+&lt;ul&gt;
+	&lt;li&gt;All basic text to speech functions&lt;/li&gt;
+	&lt;li&gt;Free to download and free to use.&lt;/li&gt;
+	&lt;li&gt;Compatible with PDF, Word, webpages&lt;/li&gt;
+	&lt;li&gt;Floating bar&lt;/li&gt;
+	&lt;li&gt;Change speaker and speed&lt;/li&gt;
+	&lt;li&gt;Can read aloud any text.&lt;/li&gt;
+	&lt;li&gt;Can adjust speed and change voice.&lt;/li&gt;
+	&lt;li&gt;Comes with a floating bar to read any text in other applications.&lt;/li&gt;
+&lt;/ul&gt;
+</string>
+			<key>developer</key>
+			<string>NaturalSoft</string>
+			<key>display_name</key>
+			<string>NaturalReader Free</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>category</key>
+			<string>%MUNKI_CATEGORY%</string>
+			<key>unattended_install</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.6.1</string>
+	<key>ParentRecipe</key>
+	<string>com.github.n8felton.download.NaturalReaderFree</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
```
$ autopkg run -v NaturalReaderFree.munki.recipe
Processing NaturalReaderFree.munki.recipe...
WARNING: NaturalReaderFree.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (version): 14
URLTextSearcher: Found matching text (match): https://s3.amazonaws.com/naturalsoftdownload-voices/software/NaturalReader14Free.pkg
URLDownloader
URLDownloader: Storing new Last-Modified header: Thu, 22 Oct 2015 02:48:14 GMT
URLDownloader: Storing new ETag header: "c1cd738d351e2f6af199980528137ffa"
URLDownloader: Downloaded /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.NaturalReaderFree/downloads/NaturalReaderFree.pkg
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {
    version = 14;
} into pkginfo
MunkiImporter
MunkiImporter: Copied pkginfo to /munki/pkgsinfo/apps/NaturalReaderFree/NaturalReaderFree-14.plist
MunkiImporter: Copied pkg to /munki/pkgs/apps/NaturalReaderFree/NaturalReaderFree-14.pkg
Receipt written to /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.NaturalReaderFree/receipts/NaturalReaderFree.munki-receipt-20170602-110205.plist

The following new items were imported into Munki:
    Name               Version  Catalogs  Pkginfo Path                                       Pkg Repo Path
    ----               -------  --------  ------------                                       -------------
    NaturalReaderFree  14       testing   apps/NaturalReaderFree/NaturalReaderFree-14.plist  apps/NaturalReaderFree/NaturalReaderFree-14.pkg

The following new items were downloaded:
    Download Path
    -------------
    /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.NaturalReaderFree/downloads/NaturalReaderFree.pkg
```