### PR TITLE
[KeePassXC] Add download and munki recipes

### DIFF
--- a/KeePassX/KeePassXC.download.recipe
+++ b/KeePassX/KeePassXC.download.recipe
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest release of KeePassXC from Github.</string>
+	<key>Identifier</key>
+	<string>com.github.n8felton.download.KeePassXC</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>KeePassXC</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.6.0</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>asset_regex</key>
+				<string>KeePassXC-.+\.dmg</string>
+				<key>github_repo</key>
+				<string>keepassxreboot/keepassxc</string>
+				<key>include_prereleases</key>
+				<false/>
+			</dict>
+			<key>Processor</key>
+			<string>GitHubReleasesInfoProvider</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/KeePassX/KeePassXC.munki.recipe
+++ b/KeePassX/KeePassXC.munki.recipe
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest release of KeePassXC and imports it into Munki.</string>
+	<key>Identifier</key>
+	<string>com.github.n8felton.munki.KeePassXC</string>
+	<key>Input</key>
+	<dict>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>apps/%NAME%</string>
+		<key>NAME</key>
+		<string>KeePassXC</string>
+		<key>MUNKI_CATEGORY</key>
+		<string>Utilities</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>description</key>
+			<string>&lt;a target='new' href='https://keepassxc.org/'&gt;KeePassXC&lt;/a&gt; is a community fork of KeePassX with the goal to extend and improve it with new features and bugfixes to provide a feature-rich, fully cross-platform and modern open-source password manager.&lt;br&gt;
+&lt;br&gt;
+&lt;h5&gt;Additional Features&lt;/h5&gt;
+&lt;ul&gt;
+&lt;li&gt;Auto-Type on all three major platforms (Linux, Windows, macOS)&lt;/li&gt;
+&lt;li&gt;Twofish encryption&lt;/li&gt;
+&lt;li&gt;YubiKey challenge-response support&lt;/li&gt;
+&lt;li&gt;TOTP generation&lt;/li&gt;
+&lt;li&gt;CSV import&lt;/li&gt;
+&lt;li&gt;Command line interface&lt;/li&gt;
+&lt;li&gt;DEP and ASLR hardening&lt;/li&gt;
+&lt;li&gt;Stand-alone password and passphrase generator&lt;/li&gt;
+&lt;li&gt;Password strength meter&lt;/li&gt;
+&lt;li&gt;Using website favicons as entry icons&lt;/li&gt;
+&lt;li&gt;Merging of databases&lt;/li&gt;
+&lt;li&gt;Automatic reload when the database was changed externally&lt;/li&gt;
+&lt;li&gt;Many bug fixes&lt;/li&gt;
+&lt;/ul&gt;
+</string>
+			<key>developer</key>
+			<string>KeePassXC</string>
+			<key>display_name</key>
+			<string>KeePassXC</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>category</key>
+			<string>%MUNKI_CATEGORY%</string>
+			<key>unattended_install</key>
+			<true/>
+			<key>uninstall_method</key>
+			<string>uninstall_script</string>
+		</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.6.1</string>
+	<key>ParentRecipe</key>
+	<string>com.github.n8felton.download.KeePassXC</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
```
$ autopkg run KeePassXC.munki.recipe -v
Processing KeePassXC.munki.recipe...
WARNING: KeePassXC.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
GitHubReleasesInfoProvider: Matched regex 'KeePassXC-.+\.dmg' among asset(s): keepassxc-2.2.0-src.tar.xz, keepassxc-2.2.0-src.tar.xz.DIGEST, keepassxc-2.2.0-src.tar.xz.sig, KeePassXC-2.2.0-Win32-Portable.zip, KeePassXC-2.2.0-Win32-Portable.zip.DIGEST, KeePassXC-2.2.0-Win32-Portable.zip.sig, KeePassXC-2.2.0-Win32.exe, KeePassXC-2.2.0-Win32.exe.DIGEST, KeePassXC-2.2.0-Win32.exe.sig, KeePassXC-2.2.0-Win64-Portable.zip, KeePassXC-2.2.0-Win64-Portable.zip.DIGEST, KeePassXC-2.2.0-Win64-Portable.zip.sig, KeePassXC-2.2.0-Win64.exe, KeePassXC-2.2.0-Win64.exe.DIGEST, KeePassXC-2.2.0-Win64.exe.sig, KeePassXC-2.2.0-x86_64.AppImage, KeePassXC-2.2.0-x86_64.AppImage.DIGEST, KeePassXC-2.2.0-x86_64.AppImage.sig, KeePassXC-2.2.0.dmg, KeePassXC-2.2.0.dmg.DIGEST, KeePassXC-2.2.0.dmg.sig
GitHubReleasesInfoProvider: Selected asset 'KeePassXC-2.2.0.dmg' from release ''
URLDownloader
URLDownloader: Storing new Last-Modified header: Sun, 25 Jun 2017 23:58:04 GMT
URLDownloader: Storing new ETag header: "b824ea7debb8921b9b10d6c632d66aac"
URLDownloader: Downloaded /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.KeePassXC/downloads/KeePassXC-2.2.0.dmg
EndOfCheckPhase
MunkiImporter
MunkiImporter: Copied pkginfo to /munki/pkgsinfo/apps/KeePassXC/KeePassXC-2.2.0.plist
MunkiImporter: Copied pkg to /munki/pkgs/apps/KeePassXC/KeePassXC-2.2.0.dmg
Receipt written to /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.KeePassXC/receipts/KeePassXC.munki-receipt-20170706-104847.plist

The following new items were imported into Munki:
    Name       Version  Catalogs  Pkginfo Path                          Pkg Repo Path                       
    ----       -------  --------  ------------                          -------------                       
    KeePassXC  2.2.0    testing   apps/KeePassXC/KeePassXC-2.2.0.plist  apps/KeePassXC/KeePassXC-2.2.0.dmg  

The following new items were downloaded:
    Download Path                                                                                            
    -------------                                                                                            
    /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.KeePassXC/downloads/KeePassXC-2.2.0.dmg  
```