### PR TITLE
Update Apple ARTICLE_NUMBER to match new update

### DIFF
--- a/ApplePrinterDrivers/AppleEpsonPrinterDrivers.download.recipe
+++ b/ApplePrinterDrivers/AppleEpsonPrinterDrivers.download.recipe
@@ -19,7 +19,7 @@
             <key>Arguments</key>
             <dict>
                 <key>ARTICLE_NUMBER</key>
-                <string>1792</string>
+                <string>1925</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Even though the new page only refers to Lion through Yosemite, SUS is only serving one update, so this must be the one.