### PR TITLE
Update KeePassXC munki uninstall_method. Fixes #62

### DIFF
--- a/KeePassXC/KeePassXC.munki.recipe
+++ b/KeePassXC/KeePassXC.munki.recipe
@@ -48,10 +48,8 @@
 			<string>%NAME%</string>
 			<key>category</key>
 			<string>%MUNKI_CATEGORY%</string>
-			<key>unattended_install</key>
-			<true/>
 			<key>uninstall_method</key>
-			<string>uninstall_script</string>
+			<string>remove_copied_items</string>
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>


### PR DESCRIPTION
Also removed the unattended install bit because you can set that in an override if you really want.
