### PR TITLE
[Pentaho/DataIntegration] Fixed pkg_path for the munki import

### DIFF
--- a/Pentaho/DataIntegration.munki.recipe
+++ b/Pentaho/DataIntegration.munki.recipe
@@ -46,7 +46,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
-				<string>%pathname%</string>
+				<string>%pkg_path%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>


### PR DESCRIPTION
didn't realize I changed `pathname` to `pkg_path` on my VM without fixing it in git. 😳 