### PR TITLE
[Neo4j] Add community edition munki and download recipes

### DIFF
--- a/Neo4j/Neo4j-CE.download.recipe
+++ b/Neo4j/Neo4j-CE.download.recipe
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Download recipe for Neo4j Community Edition.</string>
+	<key>Identifier</key>
+	<string>com.github.n8felton.neo4j-ce.download</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>Neo4j-CE</string>
+	</dict>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>https://neo4j.com/download/community-edition/</string>
+				<key>re_pattern</key>
+				<string>release=(?P&lt;version&gt;[^&amp;]+)</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>com.github.homebysix.FindAndReplace/FindAndReplace</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_string</key>
+				<string>%version%</string>
+				<key>find</key>
+				<string>.</string>
+				<key>replace</key>
+				<string>_</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>https://neo4j.com/artifact.php?name=neo4j-community_macos_%output_string%.dmg</string>
+				<key>filename</key>
+				<string>%NAME%.dmg</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+	</array>
+	<key>MinimumVersion</key>
+	<string>0.2.9</string>
+</dict>
+</plist>

--- a/Neo4j/Neo4j-CE.munki.recipe
+++ b/Neo4j/Neo4j-CE.munki.recipe
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of Neo4j Community Edition and imports it into Munki.</string>
+	<key>Identifier</key>
+	<string>com.github.n8felton.neo4j-ce.munki</string>
+	<key>ParentRecipe</key>
+	<string>com.github.n8felton.neo4j-ce.download</string>
+	<key>Input</key>
+	<dict>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>apps/Neo4j</string>
+		<key>NAME</key>
+		<string>Neo4j-CE</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>description</key>
+			<string>As a native graph database, Neo4j is specifically optimized to store and traverse these graphs of connected data. By intuitively mapping data points and the connections between them, Neo4j powers intelligent, real-time applications that tackle today's toughest enterprise challenges.&lt;br&gt;&lt;br&gt;
+Default login is username &lt;strong&gt;'neo4j'&lt;/strong&gt; and password &lt;strong&gt;'neo4j'&lt;/strong&gt; (&lt;a href="https://neo4j.com/docs/operations-manual/current/introduction/" target="_blank"&gt;Neo4j Operations Manual&lt;/a&gt;)</string>
+			<key>display_name</key>
+			<string>Neo4j Community Edition</string>
+			<key>minimum_os_version</key>
+			<string>10.6.0</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>category</key>
+			<string>Math &amp; Science</string>
+			<key>developer</key>
+			<string>Neo4j</string>
+		</dict>
+	</dict>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+		</dict>
+	</array>
+	<key>MinimumVersion</key>
+	<string>0.2.9</string>
+</dict>
+</plist>


### PR DESCRIPTION
It was a pain getting the download link because of weird JavaScript and cookie stuff they're doing but I was able to generate it by converting the version number's periods to underscores. 
```
$ autopkg run Neo4j/Neo4j-CE.munki.recipe -v
Processing Neo4j/Neo4j-CE.munki.recipe...
WARNING: Neo4j/Neo4j-CE.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (version): 3.2.3
URLTextSearcher: Found matching text (match): 3.2.3
com.github.homebysix.FindAndReplace/FindAndReplace
FindAndReplace: Replacing "." with "_" in "3.2.3".
URLDownloader
URLDownloader: Downloaded /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.neo4j-ce.munki/downloads/Neo4j-CE.dmg
EndOfCheckPhase
MunkiImporter
MunkiImporter: Copied pkginfo to /munki/pkgsinfo/apps/Neo4j/Neo4j-CE-3.2.3.plist
MunkiImporter: Copied pkg to /munki/pkgs/apps/Neo4j/Neo4j-CE-3.2.3.dmg
Receipt written to /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.neo4j-ce.munki/receipts/Neo4j-CE.munki-receipt-20170825-065855.plist

The following new items were imported into Munki:
    Name      Version  Catalogs  Pkginfo Path                        Pkg Repo Path                     
    ----      -------  --------  ------------                        -------------                     
    Neo4j-CE  3.2.3    testing   apps/Neo4j/Neo4j-CE-3.2.3.plist  apps/Neo4j/Neo4j-CE-3.2.3.dmg  

The following new items were downloaded:
    Download Path                                                                                    
    -------------                                                                                    
    /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.neo4j-ce.munki/downloads/Neo4j-CE.dmg  
```