### PR TITLE
[Weka] Rename app when it copies

### DIFF
--- a/Weka/Weka.download.recipe
+++ b/Weka/Weka.download.recipe
@@ -38,6 +38,30 @@
 			<key>Processor</key>
 			<string>com.github.n8felton.shared/MD5Checksum</string>
 		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>Copier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>source_path</key>
+				<string>%pathname%/*.app</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/Weka/Weka.app</string>
+				<key>overwrite</key>
+				<true/>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>DmgCreator</string>
+			<key>Arguments</key>
+			<dict>
+				<key>dmg_root</key>
+				<string>%RECIPE_CACHE_DIR%/Weka</string>
+				<key>dmg_path</key>
+				<string>%RECIPE_CACHE_DIR%/Weka.dmg</string>
+			</dict>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/Weka/Weka.munki.recipe
+++ b/Weka/Weka.munki.recipe
@@ -44,7 +44,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
-				<string>%pathname%</string>
+				<string>%RECIPE_CACHE_DIR%/Weka.dmg</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>


### PR DESCRIPTION
Fixes #80 

Sample run:
```
$ autopkg run Weka.munki -v
Processing Weka.munki...
WARNING: Weka.munki is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
com.github.n8felton.shared/SourceForgeBestReleaseURLProvider
com.github.n8felton.shared/RemoteFilenameFinder
URLDownloader
URLDownloader: Storing new Last-Modified header: Thu, 21 Dec 2017 21:12:29 GMT
URLDownloader: Storing new ETag header: "76664ba-560e02852a940"
URLDownloader: Downloaded /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.Weka/downloads/weka-3-8-2-oracle-jvm.dmg
EndOfCheckPhase
com.github.n8felton.shared/MD5Checksum
MD5Checksum: be546bae7915ca50ca40df7aa1cffae8
MD5Checksum: MD5 Checksum Matches
Copier
Copier: Mounted disk image /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.Weka/downloads/weka-3-8-2-oracle-jvm.dmg
Copier: Using path '/private/tmp/dmg.3Sh1Sj/weka-3-8-2-oracle-jvm.app' matched from globbed '/private/tmp/dmg.3Sh1Sj/*.app'.
Copier: Copied /private/tmp/dmg.3Sh1Sj/weka-3-8-2-oracle-jvm.app to /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.Weka/Weka/Weka.app
DmgCreator
DmgCreator: Created dmg from /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.Weka/Weka at /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.Weka/Weka.dmg
MunkiImporter
MunkiImporter: Copied pkginfo to /munki/pkgsinfo/apps/Weka/Weka-3.8.2.plist
MunkiImporter: Copied pkg to /munki/pkgs/apps/Weka/Weka-3.8.2.dmg
Receipt written to /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.Weka/receipts/Weka-receipt-20180112-110448.plist

The following new items were imported into Munki:
    Name  Version  Catalogs  Pkginfo Path                Pkg Repo Path             
    ----  -------  --------  ------------                -------------             
    Weka  3.8.2    testing   apps/Weka/Weka-3.8.2.plist  apps/Weka/Weka-3.8.2.dmg  

The following new items were downloaded:
    Download Path                                                                                             
    -------------                                                                                             
    /Users/cwhits/Library/AutoPkg/Cache/com.github.n8felton.munki.Weka/downloads/weka-3-8-2-oracle-jvm.dmg  
```