### PR TITLE
Update re_pattern for Geneious

### DIFF
--- a/Geneious/Geneious.download.recipe
+++ b/Geneious/Geneious.download.recipe
@@ -32,7 +32,7 @@ See http://desktop-links.geneious.com/assets/installers/geneious/GeneiousVersion
 				<key>url</key>
 				<string>%VERSIONS_URL%</string>
 				<key>re_pattern</key>
-				<string>%MAJOR_VERSION% %RELEASE% %RELEASE%.*(Geneious.*mac.*)</string>
+				<string>%MAJOR_VERSION% %RELEASE% %RELEASE%.*(Geneious.*mac.*dmg)</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
The download recipe will fail with `URLDownloader: Error: Curl failure: Illegal characters found in URL (exit code 3)` the reason for this appeares to be an end of line character in `GeneiousVersions.txt`. Notice the `\r` in the following output:

```
  URLTextSearcher: Found matching text (match): Geneious_mac64_10_2_6_with_jre.dmg
  {'Output': {'match': 'Geneious_mac64_10_2_6_with_jre.dmg\r'}}
  URLDownloader
  {'Input': {'CURL_PATH': '/usr/bin/curl',
             'url': u'https://assets.geneious.com/installers/geneious/release/Geneious_mac64_10_2_6_with_jre.dmg\r'}}
```

We avoide this problem by updating the re_pattern to explicitely search for a string ending with `dmg`.

