### PR TITLE
Update MAMP.download recipe

### DIFF
--- a/MAMP/MAMP.download.recipe
+++ b/MAMP/MAMP.download.recipe
@@ -50,7 +50,7 @@
 				<string>%pathname%</string>
 				<key>expected_authority_names</key>
 				<array>
-					<string>Developer ID Installer: appsolute GmbH (3NP792379T)</string>
+					<string>Developer ID Installer: MAMP GmbH (5KCB5KHK77)</string>
 					<string>Developer ID Certification Authority</string>
 					<string>Apple Root CA</string>
 				</array>


### PR DESCRIPTION
MAMP has changed their org name, which results in a new cert name to be verified to.