### PR TITLE
Update MAMP.download.recipe

### DIFF
--- a/MAMP/MAMP.download.recipe
+++ b/MAMP/MAMP.download.recipe
@@ -50,7 +50,7 @@
 				<string>%pathname%</string>
 				<key>expected_authority_names</key>
 				<array>
-					<string>Developer ID Installer: appsolute GmbH (3NP792379T)</string>
+					<string>Developer ID Installer: MAMP GmbH (5KCB5KHK77)</string>
 					<string>Developer ID Certification Authority</string>
 					<string>Apple Root CA</string>
 				</array>


### PR DESCRIPTION
Updated Developer ID Installer value.

```
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "MAMP_MAMP_PRO_5.3.pkg":
CodeSignatureVerifier:    Status: signed by a certificate trusted by Mac OS X
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: MAMP GmbH (5KCB5KHK77)
CodeSignatureVerifier:        SHA1 fingerprint: 2D DA 10 A7 75 3A 7B 49 97 47 BF FD E7 38 84 B3 8B 38 FE 54
CodeSignatureVerifier:        -----------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        SHA1 fingerprint: 3B 16 6C 3B 7D C4 B7 51 C9 FE 2A FA B9 13 56 41 E3 88 E1 86
CodeSignatureVerifier:        -----------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        SHA1 fingerprint: 61 1E 5B 66 2C 59 3A 08 FF 58 D1 4A E2 24 52 D1 98 DF 6C 60
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Mismatch in authority names
CodeSignatureVerifier: Expected: Developer ID Installer: appsolute GmbH (3NP792379T) -> Developer ID Certification Authority -> Apple Root CA
CodeSignatureVerifier: Found:    Developer ID Installer: MAMP GmbH (5KCB5KHK77) -> Developer ID Certification Authority -> Apple Root CA
Mismatch in authority names. Note that all verification can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.
Failed.
```