### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/BlueJ/BlueJ.download.recipe
+++ b/BlueJ/BlueJ.download.recipe
@@ -60,7 +60,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>pattern</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/*/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/*/BlueJ.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>FileFinder</string>

--- a/BlueJ/BlueJ.install.recipe
+++ b/BlueJ/BlueJ.install.recipe
@@ -39,7 +39,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>BlueJ.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/BlueJ/BlueJ.munki.recipe
+++ b/BlueJ/BlueJ.munki.recipe
@@ -44,7 +44,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>pattern</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/*/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/*/BlueJ.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>FileFinder</string>

--- a/Chimera/Chimera.download.recipe
+++ b/Chimera/Chimera.download.recipe
@@ -62,7 +62,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Chimera.app</string>
 				<key>requirement</key>
 				<string>identifier "edu.ucsf.cgl.chimera" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = LWV8X224YF</string>
 			</dict>

--- a/Cn3D/Cn3D.munki.recipe
+++ b/Cn3D/Cn3D.munki.recipe
@@ -48,7 +48,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>pattern</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Cn3D.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>FileFinder</string>

--- a/Flixel/Cinemagraph Pro.download.recipe
+++ b/Flixel/Cinemagraph Pro.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Cinemagraph Pro.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.flixel.mac.cinemagraphpro" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "8D2X524S6C")</string>
 			</dict>

--- a/Flixel/Cinemagraph Pro.install.recipe
+++ b/Flixel/Cinemagraph Pro.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Cinemagraph Pro.app</string>
 					</dict>
 				</array>
 			</dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.