### PR TITLE
Basic python3 compatibility

### DIFF
--- a/IntelXDK/IntelXDKInfoProvider.py
+++ b/IntelXDK/IntelXDKInfoProvider.py
@@ -17,6 +17,7 @@
 """"Update information provider for Intel XDK"""
 
 from __future__ import absolute_import
+
 import json
 
 from autopkglib import Processor, ProcessorError

--- a/IntelXDK/IntelXDKInfoProvider.py
+++ b/IntelXDK/IntelXDKInfoProvider.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 """"Update information provider for Intel XDK"""
 
+from __future__ import absolute_import
 import urllib2
 import json
 

--- a/IntelXDK/IntelXDKInfoProvider.py
+++ b/IntelXDK/IntelXDKInfoProvider.py
@@ -63,7 +63,7 @@ class IntelXDKInfoProvider(Processor):
         """Returns a JSON response using the XDK client update source"""
         try:
             response = urlopen(updates_url)
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError("Can't open %s: %s" % (updates_url, e))
 
         releases = json.loads(response.read())

--- a/IntelXDK/IntelXDKInfoProvider.py
+++ b/IntelXDK/IntelXDKInfoProvider.py
@@ -17,10 +17,14 @@
 """"Update information provider for Intel XDK"""
 
 from __future__ import absolute_import
-import urllib2
 import json
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.parse import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["IntelXDKInfoProvider"]
 
@@ -57,8 +61,7 @@ class IntelXDKInfoProvider(Processor):
     def get_xdk_updates(cls, updates_url):
         """Returns a JSON response using the XDK client update source"""
         try:
-            request = urllib2.Request(updates_url)
-            response = urllib2.urlopen(request)
+            response = urlopen(updates_url)
         except BaseException as e:
             raise ProcessorError("Can't open %s: %s" % (updates_url, e))
 

--- a/Microsoft/MicrosoftEdgeURLProvider.py
+++ b/Microsoft/MicrosoftEdgeURLProvider.py
@@ -60,5 +60,5 @@ class MicrosoftEdgeURLProvider(Processor):
 
 
 if __name__ == "__main__":
-    PROCESSOR = MirosoftEdgeURLProvider()
+    PROCESSOR = MicrosoftEdgeURLProvider()
     PROCESSOR.execute_shell()

--- a/Microsoft/MicrosoftEdgeURLProvider.py
+++ b/Microsoft/MicrosoftEdgeURLProvider.py
@@ -15,8 +15,8 @@
 # limitations under the License.
 """See docstring for MicrosoftEdgeURLProvider class"""
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
+
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["MicrosoftEdgeURLProvider"]

--- a/Microsoft/MicrosoftEdgeURLProvider.py
+++ b/Microsoft/MicrosoftEdgeURLProvider.py
@@ -42,7 +42,7 @@ class MicrosoftEdgeURLProvider(Processor):
             "default": "Beta",
             "description": (
                 "Which channel to download. "
-                "Options: {}".format(CHANNEL_LINKID.keys())
+                "Options: {}".format(', '.join(CHANNEL_LINKID))
             ),
         }
     }

--- a/Microsoft/MicrosoftEdgeURLProvider.py
+++ b/Microsoft/MicrosoftEdgeURLProvider.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 """See docstring for MicrosoftEdgeURLProvider class"""
 
+from __future__ import absolute_import
+from __future__ import print_function
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["MicrosoftEdgeURLProvider"]
@@ -51,7 +53,7 @@ class MicrosoftEdgeURLProvider(Processor):
 
     def main(self):
         channel = self.env.get("CHANNEL") or self.input_variables["CHANNEL"]["default"]
-        print(self.input_variables["CHANNEL"]["description"])
+        print((self.input_variables["CHANNEL"]["description"]))
         url = MS_LINKID_URL.format(linkid=CHANNEL_LINKID[channel])
         self.env["url"] = url
         self.env["CHANNEL"] = channel

--- a/SharedProcessors/AppleSupportDownloadInfoProvider.py
+++ b/SharedProcessors/AppleSupportDownloadInfoProvider.py
@@ -69,7 +69,7 @@ class AppleSupportDownloadInfoProvider(Processor):
         """Follows HTTP 302 redirects to fetch the final url of a download."""
         try:
             response = urlopen(download_url)
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError("Can't download %s: %s" % (download_url, e))
 
         return response.geturl()
@@ -80,7 +80,7 @@ class AppleSupportDownloadInfoProvider(Processor):
 
         try:
             response = urlopen(article_url)
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError("Unable to access %s: %s" % (article_url, e))
 
         info = response.info()

--- a/SharedProcessors/AppleSupportDownloadInfoProvider.py
+++ b/SharedProcessors/AppleSupportDownloadInfoProvider.py
@@ -17,6 +17,7 @@
 """Shared processor to allow recipes to download Apple support downloads."""
 
 from __future__ import absolute_import
+
 import re
 
 from autopkglib import Processor, ProcessorError

--- a/SharedProcessors/AppleSupportDownloadInfoProvider.py
+++ b/SharedProcessors/AppleSupportDownloadInfoProvider.py
@@ -79,7 +79,7 @@ class AppleSupportDownloadInfoProvider(Processor):
 
         try:
             response = urlopen(article_url)
-        except Exception as e:
+        except BaseException as e:
             raise ProcessorError("Unable to access %s: %s" % (article_url, e))
 
         info = response.info()

--- a/SharedProcessors/AppleSupportDownloadInfoProvider.py
+++ b/SharedProcessors/AppleSupportDownloadInfoProvider.py
@@ -17,10 +17,14 @@
 """Shared processor to allow recipes to download Apple support downloads."""
 
 from __future__ import absolute_import
-import urllib2
 import re
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.parse import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["AppleSupportDownloadInfoProvider"]
 
@@ -63,8 +67,7 @@ class AppleSupportDownloadInfoProvider(Processor):
     def get_url(cls, download_url):
         """Follows HTTP 302 redirects to fetch the final url of a download."""
         try:
-            request = urllib2.Request(download_url)
-            response = urllib2.urlopen(request)
+            response = urlopen(download_url)
         except BaseException as e:
             raise ProcessorError("Can't download %s: %s" % (download_url, e))
 
@@ -75,10 +78,8 @@ class AppleSupportDownloadInfoProvider(Processor):
         """Retrieve the HTML <title> from a webpage"""
 
         try:
-            response = urllib2.urlopen(article_url)
-        except urllib2.HTTPError as e:
-            raise ProcessorError("Unable to access %s: %s" % (article_url, e))
-        except urllib2.URLError as e:
+            response = urlopen(article_url)
+        except Exception as e:
             raise ProcessorError("Unable to access %s: %s" % (article_url, e))
 
         info = response.info()

--- a/SharedProcessors/AppleSupportDownloadInfoProvider.py
+++ b/SharedProcessors/AppleSupportDownloadInfoProvider.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 """Shared processor to allow recipes to download Apple support downloads."""
 
+from __future__ import absolute_import
 import urllib2
 import re
 
@@ -75,9 +76,9 @@ class AppleSupportDownloadInfoProvider(Processor):
 
         try:
             response = urllib2.urlopen(article_url)
-        except urllib2.HTTPError, e:
+        except urllib2.HTTPError as e:
             raise ProcessorError("Unable to access %s: %s" % (article_url, e))
-        except urllib2.URLError, e:
+        except urllib2.URLError as e:
             raise ProcessorError("Unable to access %s: %s" % (article_url, e))
 
         info = response.info()

--- a/SharedProcessors/AppleSupportDownloadInfoProvider.py
+++ b/SharedProcessors/AppleSupportDownloadInfoProvider.py
@@ -86,13 +86,13 @@ class AppleSupportDownloadInfoProvider(Processor):
         info = response.info()
         try:
             content_type = info['Content-Type']
-            if not re.match(".*/html.*", content_type):
+            if not re.match(r".*/html.*", content_type):
                 raise ProcessorError("Unable to access %s" % article_url)
         except:
             raise ProcessorError("Unable to access %s: %s" % (article_url, e))
 
         head = response.read(8192)
-        head = re.sub("[\r\n\t ]", " ", head)
+        head = re.sub(r"[\r\n\t ]", " ", head)
 
         title = re.search(r'(?i)\<title\>(.*?)\</title\>', head)
         if title:

--- a/SharedProcessors/AppleSupportDownloadInfoProvider.py
+++ b/SharedProcessors/AppleSupportDownloadInfoProvider.py
@@ -86,8 +86,7 @@ class AppleSupportDownloadInfoProvider(Processor):
         try:
             content_type = info['Content-Type']
             if not re.match(".*/html.*", content_type):
-                raise ProcessorError("Unable to access %s: %s" % (article_url,
-                                                                  e))
+                raise ProcessorError("Unable to access %s" % article_url)
         except:
             raise ProcessorError("Unable to access %s: %s" % (article_url, e))
 

--- a/SharedProcessors/DistributionInfoProvider.py
+++ b/SharedProcessors/DistributionInfoProvider.py
@@ -17,7 +17,9 @@
 """"Information provider using the Distribution file of product bundles"""
 
 from __future__ import absolute_import
+
 import xml.etree.ElementTree as ET
+
 from autopkglib import Processor
 
 __all__ = ["DistributionInfoProvider"]

--- a/SharedProcessors/DistributionInfoProvider.py
+++ b/SharedProcessors/DistributionInfoProvider.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 """"Information provider using the Distribution file of product bundles"""
 
+from __future__ import absolute_import
 import xml.etree.ElementTree as ET
 from autopkglib import Processor
 

--- a/SharedProcessors/HPSoftwareInfoProvider.py
+++ b/SharedProcessors/HPSoftwareInfoProvider.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 """"Information provider for HP software downloads"""
 
+from __future__ import absolute_import
 import urllib2
 import json
 

--- a/SharedProcessors/HPSoftwareInfoProvider.py
+++ b/SharedProcessors/HPSoftwareInfoProvider.py
@@ -78,7 +78,7 @@ class HPSoftwareInfoProvider(Processor):
         try:
             request = urllib2.Request(software_url)
             response = urllib2.urlopen(request)
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError("Can't open %s: %s" % (software_url, e))
 
         releases = json.loads(response.read())

--- a/SharedProcessors/HPSoftwareInfoProvider.py
+++ b/SharedProcessors/HPSoftwareInfoProvider.py
@@ -17,8 +17,9 @@
 """"Information provider for HP software downloads"""
 
 from __future__ import absolute_import
-import urllib2
+
 import json
+import urllib2
 
 from autopkglib import Processor, ProcessorError
 

--- a/SharedProcessors/MD5Checksum.py
+++ b/SharedProcessors/MD5Checksum.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 """Calculate a message-digest fingerprint (checksum) for a file"""
 
+from __future__ import absolute_import
 import hashlib
 
 from autopkglib import Processor, ProcessorError

--- a/SharedProcessors/MD5Checksum.py
+++ b/SharedProcessors/MD5Checksum.py
@@ -17,6 +17,7 @@
 """Calculate a message-digest fingerprint (checksum) for a file"""
 
 from __future__ import absolute_import
+
 import hashlib
 
 from autopkglib import Processor, ProcessorError

--- a/SharedProcessors/MunkiGitCommitter.py
+++ b/SharedProcessors/MunkiGitCommitter.py
@@ -16,11 +16,11 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import subprocess
 
-from autopkglib import Processor, ProcessorError
-from autopkglib import get_pref
+from autopkglib import Processor, ProcessorError, get_pref
 
 __all__ = ["MunkiGitCommitter"]
 

--- a/SharedProcessors/MunkiGitCommitter.py
+++ b/SharedProcessors/MunkiGitCommitter.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import subprocess
 

--- a/SharedProcessors/PkgInfoVersioner.py
+++ b/SharedProcessors/PkgInfoVersioner.py
@@ -17,7 +17,9 @@
 """"Changes the version of a flat package by modifying it's PackageInfo"""
 
 from __future__ import absolute_import
+
 import xml.etree.ElementTree as ET
+
 from autopkglib import Processor
 
 __all__ = ["PkgInfoVersioner"]

--- a/SharedProcessors/PkgInfoVersioner.py
+++ b/SharedProcessors/PkgInfoVersioner.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 """"Changes the version of a flat package by modifying it's PackageInfo"""
 
+from __future__ import absolute_import
 import xml.etree.ElementTree as ET
 from autopkglib import Processor
 

--- a/SharedProcessors/RemoteFilenameFinder.py
+++ b/SharedProcessors/RemoteFilenameFinder.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 """Finds the proper file name for a download."""
 
+from __future__ import absolute_import
 import subprocess
 from urllib2 import unquote
 from autopkglib import Processor, ProcessorError

--- a/SharedProcessors/RemoteFilenameFinder.py
+++ b/SharedProcessors/RemoteFilenameFinder.py
@@ -17,8 +17,10 @@
 """Finds the proper file name for a download."""
 
 from __future__ import absolute_import
+
 import subprocess
 from urllib2 import unquote
+
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["RemoteFilenameFinder"]

--- a/SharedProcessors/RubyGemInfoProvider.py
+++ b/SharedProcessors/RubyGemInfoProvider.py
@@ -17,8 +17,9 @@
 """Provides information about the latest version of a given Ruby gem"""
 
 from __future__ import absolute_import
-import subprocess
+
 import re
+import subprocess
 
 from autopkglib import Processor, ProcessorError
 

--- a/SharedProcessors/RubyGemInfoProvider.py
+++ b/SharedProcessors/RubyGemInfoProvider.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 """Provides information about the latest version of a given Ruby gem"""
 
+from __future__ import absolute_import
 import subprocess
 import re
 

--- a/SharedProcessors/SHA1Checksum.py
+++ b/SharedProcessors/SHA1Checksum.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 """Calculate a message-digest fingerprint (checksum) for a file"""
 
+from __future__ import absolute_import
 import hashlib
 
 from autopkglib import Processor, ProcessorError

--- a/SharedProcessors/SHA1Checksum.py
+++ b/SharedProcessors/SHA1Checksum.py
@@ -17,6 +17,7 @@
 """Calculate a message-digest fingerprint (checksum) for a file"""
 
 from __future__ import absolute_import
+
 import hashlib
 
 from autopkglib import Processor, ProcessorError

--- a/SharedProcessors/SHA256Checksum.py
+++ b/SharedProcessors/SHA256Checksum.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 """Calculate a message-digest fingerprint (checksum) for a file"""
 
+from __future__ import absolute_import
 import hashlib
 
 from autopkglib import Processor, ProcessorError

--- a/SharedProcessors/SHA256Checksum.py
+++ b/SharedProcessors/SHA256Checksum.py
@@ -17,6 +17,7 @@
 """Calculate a message-digest fingerprint (checksum) for a file"""
 
 from __future__ import absolute_import
+
 import hashlib
 
 from autopkglib import Processor, ProcessorError

--- a/SharedProcessors/SentinelOneInfoProvider.py
+++ b/SharedProcessors/SentinelOneInfoProvider.py
@@ -16,6 +16,9 @@
 # limitations under the License.
 """Information provider for SentinelOne Management consoles"""
 from __future__ import absolute_import
+
+from autopkglib import Processor, ProcessorError
+
 try:
     import logging
     from management.mgmtsdk_v2.mgmt import Management
@@ -28,7 +31,6 @@ try:
 except ImportError:
     import json
 
-from autopkglib import Processor, ProcessorError
 
 __all__ = ["SentinelOneInfoProvider"]
 

--- a/SharedProcessors/SentinelOneInfoProvider.py
+++ b/SharedProcessors/SentinelOneInfoProvider.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Information provider for SentinelOne Management consoles"""
+from __future__ import absolute_import
 try:
     import logging
     from management.mgmtsdk_v2.mgmt import Management

--- a/SharedProcessors/SourceForgeBestReleaseURLProvider.py
+++ b/SharedProcessors/SourceForgeBestReleaseURLProvider.py
@@ -19,6 +19,7 @@
 """
 
 from __future__ import absolute_import
+
 import json
 
 from autopkglib import Processor, ProcessorError

--- a/SharedProcessors/SourceForgeBestReleaseURLProvider.py
+++ b/SharedProcessors/SourceForgeBestReleaseURLProvider.py
@@ -62,7 +62,7 @@ class SourceForgeBestReleaseURLProvider(Processor):
         """Returns the JSON response using the SourceForge Release API"""
         try:
             response = urlopen(project_url)
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError("Can't open %s: %s" % (project_url, e))
 
         releases = json.loads(response.read())

--- a/SharedProcessors/SourceForgeBestReleaseURLProvider.py
+++ b/SharedProcessors/SourceForgeBestReleaseURLProvider.py
@@ -18,6 +18,7 @@
    "Best Release".
 """
 
+from __future__ import absolute_import
 import urllib2
 import json
 

--- a/SharedProcessors/SourceForgeBestReleaseURLProvider.py
+++ b/SharedProcessors/SourceForgeBestReleaseURLProvider.py
@@ -19,10 +19,14 @@
 """
 
 from __future__ import absolute_import
-import urllib2
 import json
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.parse import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["SourceForgeBestReleaseURLProvider"]
 
@@ -56,8 +60,7 @@ class SourceForgeBestReleaseURLProvider(Processor):
     def get_project_best_release(cls, project_url):
         """Returns the JSON response using the SourceForge Release API"""
         try:
-            request = urllib2.Request(project_url)
-            response = urllib2.urlopen(request)
+            response = urlopen(project_url)
         except BaseException as e:
             raise ProcessorError("Can't open %s: %s" % (project_url, e))
 

--- a/SharedProcessors/YAML.py
+++ b/SharedProcessors/YAML.py
@@ -50,7 +50,7 @@ class YAML(Processor):
         """Returns the YAML file at the given URL"""
         try:
             response = urlopen(yaml_url)
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError("Can't open %s: %s" % (yaml_url, e))
 
         releases = yaml.load(response.read())

--- a/SharedProcessors/YAML.py
+++ b/SharedProcessors/YAML.py
@@ -17,6 +17,7 @@
 """Generic processor to parse YAML into usable autopkg variables"""
 
 from __future__ import absolute_import
+
 import yaml
 
 from autopkglib import Processor, ProcessorError

--- a/SharedProcessors/YAML.py
+++ b/SharedProcessors/YAML.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 """Generic processor to parse YAML into usable autopkg variables"""
 
+from __future__ import absolute_import
 import urllib2
 import yaml
 

--- a/SharedProcessors/YAML.py
+++ b/SharedProcessors/YAML.py
@@ -17,10 +17,14 @@
 """Generic processor to parse YAML into usable autopkg variables"""
 
 from __future__ import absolute_import
-import urllib2
 import yaml
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.parse import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["YAML"]
 
@@ -44,8 +48,7 @@ class YAML(Processor):
     def get_yaml(cls, yaml_url):
         """Returns the YAML file at the given URL"""
         try:
-            request = urllib2.Request(yaml_url)
-            response = urllib2.urlopen(request)
+            response = urlopen(yaml_url)
         except BaseException as e:
             raise ProcessorError("Can't open %s: %s" % (yaml_url, e))
 


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later (including `urllib2.unquote`), but this should catch the low-hanging fruit right now.