### PR TITLE
Allow users to override INCLUDE_PRERELEASES for OpenRefine

### DIFF
--- a/OpenRefine/OpenRefine.download.recipe
+++ b/OpenRefine/OpenRefine.download.recipe
@@ -3,13 +3,19 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current release of OpenRefine from Github.</string>
+	<string>Downloads the current release of OpenRefine from Github.
+	
+By default, "pre-releases" are included. Set INCLUDE_PRERELEASES
+to an empty value to only download releases on GitHub marked as
+"final."</string>
 	<key>Identifier</key>
 	<string>com.github.n8felton.download.OpenRefine</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
 		<string>OpenRefine</string>
+                <key>INCLUDE_PRERELEASES</key>
+                <string>true</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.0</string>
@@ -23,7 +29,7 @@
 				<key>github_repo</key>
 				<string>OpenRefine/OpenRefine</string>
 				<key>include_prereleases</key>
-				<true/>
+				<string>%INCLUDE_PRERELEASES%</string>
 			</dict>
 			<key>Processor</key>
 			<string>GitHubReleasesInfoProvider</string>

--- a/OpenRefine/OpenRefine.download.recipe
+++ b/OpenRefine/OpenRefine.download.recipe
@@ -5,9 +5,8 @@
 	<key>Description</key>
 	<string>Downloads the current release of OpenRefine from Github.
 	
-By default, "pre-releases" are included. Set INCLUDE_PRERELEASES
-to an empty value to only download releases on GitHub marked as
-"final."</string>
+By default, only "stable" releases are included. Set INCLUDE_PRERELEASES
+to a non-empty value to include releases on GitHub marked as "pre-releases."</string>
 	<key>Identifier</key>
 	<string>com.github.n8felton.download.OpenRefine</string>
 	<key>Input</key>
@@ -15,7 +14,7 @@ to an empty value to only download releases on GitHub marked as
 		<key>NAME</key>
 		<string>OpenRefine</string>
                 <key>INCLUDE_PRERELEASES</key>
-                <string>true</string>
+                <string></string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.0</string>


### PR DESCRIPTION
These changes should allow users to override the INCLUDE_PRERELEASES variable in their override without changing existing behavior (which is to include pre-releases).