### PR TITLE
Update KeePassXC download recipe for latest Github release

### DIFF
--- a/KeePassXC/KeePassXC.download.recipe
+++ b/KeePassXC/KeePassXC.download.recipe
@@ -10,6 +10,8 @@
 	<dict>
 		<key>NAME</key>
 		<string>KeePassXC</string>
+		<key>ASSET_REGEX</key>
+		<string>KeePassXC-.*(?&lt;!Sierra)\.dmg</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.0</string>
@@ -19,7 +21,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>asset_regex</key>
-				<string>KeePassXC-.+\.dmg</string>
+				<string>%ASSET_REGEX%</string>
 				<key>github_repo</key>
 				<string>keepassxreboot/keepassxc</string>
 				<key>include_prereleases</key>


### PR DESCRIPTION
- Update regex search given that since 2.5.2 there is now a 10.12 Sierra specific asset .dmg version on Github that's listed before the 10.13+ .dmg.  Regex simply excludes the `string` Sierra.
- Add ASSET_REGEX input variable so we can choose which version we want to grab