### PR TITLE
Update Vision.download.recipe

### DIFF
--- a/Catapult/Vision.download.recipe
+++ b/Catapult/Vision.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Vision.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Vision*.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.xosdigital.downdraft" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = YM27Y27VWH)</string>
 			</dict>


### PR DESCRIPTION
The vendor has named the app bundle "Vision 3.2.0.app" so adding a cheeky * to the input_path of the CodeSignatureVerifier processor to catch it.