### PR TITLE
Updated VMware WorkspaceONE Admin Assistant Recipes

### DIFF
--- a/VMware/VMwareAirWatchAdminAssistant.download.recipe
+++ b/VMware/VMwareAirWatchAdminAssistant.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Comment</key>
-	<string>Created with Recipe Robot v1.1.2 (https://github.com/homebysix/recipe-robot)</string>
+	<string></string>
 	<key>Description</key>
 	<string>Downloads the latest version of VMware AirWatch Admin Assistant.</string>
 	<key>Identifier</key>
@@ -12,28 +12,14 @@
 	<dict>
 		<key>NAME</key>
 		<string>VMwareAirWatchAdminAssistant</string>
-		<key>SPARKLE_FEED_URL</key>
-		<string>https://awagent.com/AdminAssistant/VMwareAirWatchAdminAssistant.xml</string>
+		<key>url</key>
+		<string>https://getwsone.com/AdminAssistant/VMwareWorkspaceONEAdminAssistant.dmg</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
 	<key>Process</key>
 	<array>
 		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>appcast_url</key>
-				<string>%SPARKLE_FEED_URL%</string>
-			</dict>
-			<key>Processor</key>
-			<string>SparkleUpdateInfoProvider</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>filename</key>
-				<string>%NAME%-%version%.dmg</string>
-			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>

--- a/VMware/VMwareAirWatchAdminAssistant.install.recipe
+++ b/VMware/VMwareAirWatchAdminAssistant.install.recipe
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Comment</key>
+	<string></string>
+	<key>Description</key>
+	<string>Installs the latest version of VMware AirWatch Admin Assistant.</string>
+	<key>Identifier</key>
+	<string>com.github.n8felton.install.VMwareAirWatchAdminAssistant</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>VMwareAirWatchAdminAssistant</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.n8felton.download.VMwareAirWatchAdminAssistant</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>Installer</string>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%/VMware Workspace ONE Admin Assistant.pkg</string>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/VMware/VMwareAirWatchAdminAssistant.munki.recipe
+++ b/VMware/VMwareAirWatchAdminAssistant.munki.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Comment</key>
-	<string>Created with Recipe Robot v1.1.2 (https://github.com/homebysix/recipe-robot)</string>
+	<string></string>
 	<key>Description</key>
 	<string>Downloads the latest version of VMware AirWatch Admin Assistant and imports it into Munki.</string>
 	<key>Identifier</key>
@@ -45,24 +45,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>additional_pkginfo</key>
-				<dict>
-					<key>version</key>
-					<string>%version%</string>
-				</dict>
-			</dict>
-			<key>Processor</key>
-			<string>MunkiPkginfoMerger</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>pkg_path</key>
 				<string>%pathname%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
-				<key>version</key>
-				<string>%version%</string>
 			</dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>


### PR DESCRIPTION
The Sparkle feed appears to be gone and they've switched to a static disk image download.
- https://docs.vmware.com/en/VMware-Workspace-ONE-UEM/services/rn/Workspace-ONE-Admin-Assistant-for-macOS.html