### PR TITLE
Added new VMwareAirWatchAdminAssistant.install recipe

### DIFF
--- a/VMware/VMwareAirWatchAdminAssistant.install.recipe
+++ b/VMware/VMwareAirWatchAdminAssistant.install.recipe
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Comment</key>
+	<string></string>
+	<key>Description</key>
+	<string>Installs the latest version of VMware AirWatch Admin Assistant.</string>
+	<key>Identifier</key>
+	<string>com.github.n8felton.install.VMwareAirWatchAdminAssistant</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>VMwareAirWatchAdminAssistant</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.n8felton.download.VMwareAirWatchAdminAssistant</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>Installer</string>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%/VMware Workspace ONE Admin Assistant.pkg</string>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Simply installs the package from com.github.n8felton.download.VMwareAirWatchAdminAssistant

Very useful for updating AdminAssistant (with embedded munkitools) on an autopkg system