### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/ATTO/ATTODiskBenchmark.pkg.recipe
+++ b/ATTO/ATTODiskBenchmark.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.n8felton.pkg.ATTODiskBenchmark</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.ATTO.ATTODiskBenchmark</string>
 		<key>NAME</key>
 		<string>ATTO Disk Benchmark</string>
 	</dict>

--- a/Catapult/Vision.pkg.recipe
+++ b/Catapult/Vision.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.n8felton.pkg.Vision</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.xosdigital.downdraft</string>
 		<key>NAME</key>
 		<string>Vision</string>
 	</dict>

--- a/EpicGames/Epic Games Launcher.pkg.recipe
+++ b/EpicGames/Epic Games Launcher.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.n8felton.pkg.EpicGamesLauncher</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.epicgames.EpicGamesLauncher</string>
 		<key>NAME</key>
 		<string>Epic Games Launcher</string>
 	</dict>

--- a/Facebook/Spark AR Studio.pkg.recipe
+++ b/Facebook/Spark AR Studio.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.n8felton.pkg.SparkARStudio</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.facebook.arstudio.skylight</string>
 		<key>NAME</key>
 		<string>SparkARStudio</string>
 	</dict>

--- a/Microsoft/Microsoft Remote Desktop Beta.pkg.recipe
+++ b/Microsoft/Microsoft Remote Desktop Beta.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.n8felton.pkg.MicrosoftRemoteDesktopBeta</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.microsoft.rdc.osx.beta</string>
 		<key>NAME</key>
 		<string>Microsoft Remote Desktop Beta</string>
 	</dict>

--- a/Timeular/Timeular.pkg.recipe
+++ b/Timeular/Timeular.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.moofit-recipes.pkg.Timeular</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.timeular.zei</string>
 		<key>NAME</key>
 		<string>Timeular</string>
 	</dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ✅ ATTO/ATTODiskBenchmark.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/n8felton-recipes/ATTO/ATTODiskBenchmark.pkg.recipe
Processing repos/n8felton-recipes/ATTO/ATTODiskBenchmark.pkg.recipe...
URLDownloader
{'Input': {'filename': 'ATTO Disk Benchmark.dmg',
           'url': 'https://www2.atto.com/asset/18:atto-disk-benchmark-for-macos'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.ATTODiskBenchmark/downloads/ATTO Disk Benchmark.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.n8felton.pkg.ATTODiskBenchmark/downloads/ATTO '
                        'Disk Benchmark.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.n8felton.pkg.ATTODiskBenchmark/downloads/ATTO '
                         'Disk Benchmark.dmg/ATTO Disk Benchmark.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.ATTO.ATTODiskBenchmark" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = FC94733TZD)'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.ATTODiskBenchmark/downloads/ATTO Disk Benchmark.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.ZAQQda/ATTO Disk Benchmark.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.ZAQQda/ATTO Disk Benchmark.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.ZAQQda/ATTO Disk Benchmark.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.n8felton.pkg.ATTODiskBenchmark/downloads/ATTO '
                               'Disk Benchmark.dmg/ATTO Disk '
                               'Benchmark.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.ATTODiskBenchmark/downloads/ATTO Disk Benchmark.dmg
Versioner: Found version 1.00.0 in file /private/tmp/dmg.upgJnC/ATTO Disk Benchmark.app/Contents/Info.plist
{'Output': {'version': '1.00.0'}}
AppPkgCreator
{'Input': {'version': '1.00.0'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.ATTODiskBenchmark/downloads/ATTO Disk Benchmark.dmg
AppPkgCreator: Using path '/private/tmp/dmg.gveRP1/ATTO Disk Benchmark.app' matched from globbed '/private/tmp/dmg.gveRP1/*.app'.
AppPkgCreator: BundleID: com.ATTO.ATTODiskBenchmark
AppPkgCreator: Copied /private/tmp/dmg.gveRP1/ATTO Disk Benchmark.app to ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.ATTODiskBenchmark/payload/Applications/ATTO Disk Benchmark.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.ATTO.ATTODiskBenchmark',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.n8felton.pkg.ATTODiskBenchmark/ATTO '
                                                                    'Disk '
                                                                    'Benchmark-1.00.0.pkg',
                                                        'version': '1.00.0'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '1.00.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.ATTODiskBenchmark/receipts/ATTODiskBenchmark.pkg-receipt-20210213-222032.plist

The following packages were built:
    Identifier                  Version  Pkg Path                                                                                                       
    ----------                  -------  --------                                                                                                       
    com.ATTO.ATTODiskBenchmark  1.00.0   ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.ATTODiskBenchmark/ATTO Disk Benchmark-1.00.0.pkg  
```

## ❌ Catapult/Vision.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/n8felton-recipes/Catapult/Vision.pkg.recipe
Processing repos/n8felton-recipes/Catapult/Vision.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://vision-builds.catapultsports.com/vision-app-cast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 20000.3.7.1.20418
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 3.7.1 (20418)
SparkleUpdateInfoProvider: Found URL https://vision-builds.catapultsports.com/Vision3.7.1%2820418%29.zip
{'Output': {'url': 'https://vision-builds.catapultsports.com/Vision3.7.1%2820418%29.zip',
            'version': '3.7.1 (20418)'}}
URLDownloader
{'Input': {'filename': 'Vision-3.7.1 (20418).zip',
           'url': 'https://vision-builds.catapultsports.com/Vision3.7.1%2820418%29.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.Vision/downloads/Vision-3.7.1 (20418).zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.n8felton.pkg.Vision/downloads/Vision-3.7.1 '
                        '(20418).zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.n8felton.pkg.Vision/downloads/Vision-3.7.1 '
                           '(20418).zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.n8felton.pkg.Vision/Vision',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename Vision-3.7.1 (20418).zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.Vision/downloads/Vision-3.7.1 (20418).zip to ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.Vision/Vision
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.n8felton.pkg.Vision/Vision/Vision*.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.xosdigital.downdraft" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = YM27Y27VWH)'}}
CodeSignatureVerifier: Using path '~/Library/AutoPkg/Cache/com.github.n8felton.pkg.Vision/Vision/Vision.app' matched from globbed '~/Library/AutoPkg/Cache/com.github.n8felton.pkg.Vision/Vision/Vision*.app'.
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.Vision/Vision/Vision.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.Vision/Vision/Vision.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.Vision/Vision/Vision.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.n8felton.pkg.Vision/Vision/Vision.app',
           'version': '3.7.1 (20418)'}}
AppPkgCreator: BundleID: com.xosdigital.downdraft
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.Vision/Vision/Vision.app to ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.Vision/payload/Applications/Vision.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
Receipt written to ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.Vision/receipts/Vision.pkg-receipt-20210213-222038.plist

The following recipes failed:
    repos/n8felton-recipes/Catapult/Vision.pkg.recipe
        Error in com.github.n8felton.pkg.Vision: Processor: AppPkgCreator: Error: Invalid package name

Nothing downloaded, packaged or imported.
```

## ✅ EpicGames/Epic Games Launcher.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/n8felton-recipes/EpicGames/Epic\ Games\ Launcher.pkg.recipe
Processing repos/n8felton-recipes/EpicGames/Epic Games Launcher.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Epic Games Launcher.dmg',
           'url': 'https://launcher-public-service-prod06.ol.epicgames.com/launcher/api/installer/download/EpicGamesLauncher.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.EpicGamesLauncher/downloads/Epic Games Launcher.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.n8felton.pkg.EpicGamesLauncher/downloads/Epic '
                        'Games Launcher.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.n8felton.pkg.EpicGamesLauncher/downloads/Epic '
                         'Games Launcher.dmg/Epic Games Launcher.app',
           'requirement': 'identifier "com.epicgames.EpicGamesLauncher" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"96DBZ92D3Y"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.EpicGamesLauncher/downloads/Epic Games Launcher.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.3Ensee/Epic Games Launcher.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.3Ensee/Epic Games Launcher.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.3Ensee/Epic Games Launcher.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.n8felton.pkg.EpicGamesLauncher/downloads/Epic '
                               'Games Launcher.dmg/Epic Games '
                               'Launcher.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.EpicGamesLauncher/downloads/Epic Games Launcher.dmg
Versioner: Found version 10.19.2 in file /private/tmp/dmg.qYND1A/Epic Games Launcher.app/Contents/Info.plist
{'Output': {'version': '10.19.2'}}
AppPkgCreator
{'Input': {'version': '10.19.2'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.EpicGamesLauncher/downloads/Epic Games Launcher.dmg
AppPkgCreator: Using path '/private/tmp/dmg.4Rsmew/Epic Games Launcher.app' matched from globbed '/private/tmp/dmg.4Rsmew/*.app'.
AppPkgCreator: BundleID: com.epicgames.EpicGamesLauncher
AppPkgCreator: Copied /private/tmp/dmg.4Rsmew/Epic Games Launcher.app to ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.EpicGamesLauncher/payload/Applications/Epic Games Launcher.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.epicgames.EpicGamesLauncher',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.n8felton.pkg.EpicGamesLauncher/Epic '
                                                                    'Games '
                                                                    'Launcher-10.19.2.pkg',
                                                        'version': '10.19.2'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '10.19.2'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.EpicGamesLauncher/receipts/Epic Games Launcher.pkg-receipt-20210213-222112.plist

The following packages were built:
    Identifier                       Version  Pkg Path                                                                                                        
    ----------                       -------  --------                                                                                                        
    com.epicgames.EpicGamesLauncher  10.19.2  ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.EpicGamesLauncher/Epic Games Launcher-10.19.2.pkg  
```

## ✅ Facebook/Spark AR Studio.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/n8felton-recipes/Facebook/Spark\ AR\ Studio.pkg.recipe
Processing repos/n8felton-recipes/Facebook/Spark AR Studio.pkg.recipe...
URLDownloader
{'Input': {'filename': 'SparkARStudio.dmg',
           'url': 'https://www.facebook.com/sparkarmacos/download/'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.SparkARStudio/downloads/SparkARStudio.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.n8felton.pkg.SparkARStudio/downloads/SparkARStudio.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.n8felton.pkg.SparkARStudio/downloads/SparkARStudio.dmg/Spark '
                         'AR Studio.app',
           'requirement': 'identifier "com.facebook.arstudio.skylight" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'V9WTTPBFK9'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.SparkARStudio/downloads/SparkARStudio.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.uZBV9G/Spark AR Studio.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.uZBV9G/Spark AR Studio.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.uZBV9G/Spark AR Studio.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.n8felton.pkg.SparkARStudio/downloads/SparkARStudio.dmg/Spark '
                               'AR Studio.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.SparkARStudio/downloads/SparkARStudio.dmg
Versioner: Found version 106.0 in file /private/tmp/dmg.oxnuS6/Spark AR Studio.app/Contents/Info.plist
{'Output': {'version': '106.0'}}
AppPkgCreator
{'Input': {'version': '106.0'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.SparkARStudio/downloads/SparkARStudio.dmg
AppPkgCreator: Using path '/private/tmp/dmg.rK0FzS/Spark AR Studio.app' matched from globbed '/private/tmp/dmg.rK0FzS/*.app'.
AppPkgCreator: BundleID: com.facebook.arstudio.skylight
AppPkgCreator: Copied /private/tmp/dmg.rK0FzS/Spark AR Studio.app to ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.SparkARStudio/payload/Applications/Spark AR Studio.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.facebook.arstudio.skylight',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.n8felton.pkg.SparkARStudio/Spark '
                                                                    'AR '
                                                                    'Studio-106.0.pkg',
                                                        'version': '106.0'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '106.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.SparkARStudio/receipts/Spark AR Studio.pkg-receipt-20210213-222348.plist

The following packages were built:
    Identifier                      Version  Pkg Path                                                                                              
    ----------                      -------  --------                                                                                              
    com.facebook.arstudio.skylight  106.0    ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.SparkARStudio/Spark AR Studio-106.0.pkg  
```

## ✅ Microsoft/Microsoft Remote Desktop Beta.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/n8felton-recipes/Microsoft/Microsoft\ Remote\ Desktop\ Beta.pkg.recipe
Processing repos/n8felton-recipes/Microsoft/Microsoft Remote Desktop Beta.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://api.appcenter.ms/v0.1/public/sparkle/apps/5e0c1442-89a5-1fca-2d3b-fa39ce7f2b06',
           'urlencode_path_component': False}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 1857
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 10.6.0
SparkleUpdateInfoProvider: Found URL https://appcenter-filemanagement-distrib2ede6f06e.azureedge.net/b50e3b56-fcb6-4947-ae0b-5e351990d552/Microsoft%20Remote%20Desktop%20Beta.app.zip?sv=2019-02-02&sr=c&sig=G1nTQEQdmtde7F9Z6A9Y6eNZpU4tDIwbxuAUb0oCQvM%3D&se=2021-02-15T04%3A16%3A10Z&sp=r
{'Output': {'url': 'https://appcenter-filemanagement-distrib2ede6f06e.azureedge.net/b50e3b56-fcb6-4947-ae0b-5e351990d552/Microsoft%20Remote%20Desktop%20Beta.app.zip?sv=2019-02-02&sr=c&sig=G1nTQEQdmtde7F9Z6A9Y6eNZpU4tDIwbxuAUb0oCQvM%3D&se=2021-02-15T04%3A16%3A10Z&sp=r',
            'version': '10.6.0'}}
URLDownloader
{'Input': {'filename': 'Microsoft Remote Desktop Beta-10.6.0.zip',
           'url': 'https://appcenter-filemanagement-distrib2ede6f06e.azureedge.net/b50e3b56-fcb6-4947-ae0b-5e351990d552/Microsoft%20Remote%20Desktop%20Beta.app.zip?sv=2019-02-02&sr=c&sig=G1nTQEQdmtde7F9Z6A9Y6eNZpU4tDIwbxuAUb0oCQvM%3D&se=2021-02-15T04%3A16%3A10Z&sp=r'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.MicrosoftRemoteDesktopBeta/downloads/Microsoft Remote Desktop Beta-10.6.0.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.n8felton.pkg.MicrosoftRemoteDesktopBeta/downloads/Microsoft '
                        'Remote Desktop Beta-10.6.0.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.n8felton.pkg.MicrosoftRemoteDesktopBeta/downloads/Microsoft '
                           'Remote Desktop Beta-10.6.0.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.n8felton.pkg.MicrosoftRemoteDesktopBeta/Microsoft '
                               'Remote Desktop Beta',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename Microsoft Remote Desktop Beta-10.6.0.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.MicrosoftRemoteDesktopBeta/downloads/Microsoft Remote Desktop Beta-10.6.0.zip to ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.MicrosoftRemoteDesktopBeta/Microsoft Remote Desktop Beta
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.n8felton.pkg.MicrosoftRemoteDesktopBeta/Microsoft '
                         'Remote Desktop Beta/Microsoft Remote Desktop '
                         'Beta.app',
           'requirement': 'identifier "com.microsoft.rdc.osx.beta" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'UBF8T346G9'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.MicrosoftRemoteDesktopBeta/Microsoft Remote Desktop Beta/Microsoft Remote Desktop Beta.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.MicrosoftRemoteDesktopBeta/Microsoft Remote Desktop Beta/Microsoft Remote Desktop Beta.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.MicrosoftRemoteDesktopBeta/Microsoft Remote Desktop Beta/Microsoft Remote Desktop Beta.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.n8felton.pkg.MicrosoftRemoteDesktopBeta/Microsoft '
                       'Remote Desktop Beta/Microsoft Remote Desktop Beta.app',
           'version': '10.6.0'}}
AppPkgCreator: BundleID: com.microsoft.rdc.osx.beta
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.MicrosoftRemoteDesktopBeta/Microsoft Remote Desktop Beta/Microsoft Remote Desktop Beta.app to ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.MicrosoftRemoteDesktopBeta/payload/Applications/Microsoft Remote Desktop Beta.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.microsoft.rdc.osx.beta',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.n8felton.pkg.MicrosoftRemoteDesktopBeta/Microsoft '
                                                                    'Remote '
                                                                    'Desktop '
                                                                    'Beta-10.6.0.pkg',
                                                        'version': '10.6.0'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '10.6.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.MicrosoftRemoteDesktopBeta/receipts/Microsoft Remote Desktop Beta.pkg-receipt-20210213-222407.plist

The following packages were built:
    Identifier                  Version  Pkg Path                                                                                                                          
    ----------                  -------  --------                                                                                                                          
    com.microsoft.rdc.osx.beta  10.6.0   ~/Library/AutoPkg/Cache/com.github.n8felton.pkg.MicrosoftRemoteDesktopBeta/Microsoft Remote Desktop Beta-10.6.0.pkg  
```

## ✅ Timeular/Timeular.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/n8felton-recipes/Timeular/Timeular.pkg.recipe
Processing repos/n8felton-recipes/Timeular/Timeular.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Timeular.dmg',
           'url': 'https://timeular-desktop-packages.s3.amazonaws.com/mac/production/Timeular.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Timeular/downloads/Timeular.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Timeular/downloads/Timeular.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Timeular/downloads/Timeular.dmg/Timeular.app',
           'requirement': 'identifier "com.timeular.zei" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'PG5GS9SSVP'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Timeular/downloads/Timeular.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.kE9Sgi/Timeular.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.kE9Sgi/Timeular.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.kE9Sgi/Timeular.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Timeular/downloads/Timeular.dmg/Timeular.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Timeular/downloads/Timeular.dmg
Versioner: Found version 3.8.0 in file /private/tmp/dmg.iEHhdp/Timeular.app/Contents/Info.plist
{'Output': {'version': '3.8.0'}}
AppPkgCreator
{'Input': {'version': '3.8.0'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Timeular/downloads/Timeular.dmg
AppPkgCreator: Using path '/private/tmp/dmg.xveJVz/Timeular.app' matched from globbed '/private/tmp/dmg.xveJVz/*.app'.
AppPkgCreator: BundleID: com.timeular.zei
AppPkgCreator: Copied /private/tmp/dmg.xveJVz/Timeular.app to ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Timeular/payload/Applications/Timeular.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.timeular.zei',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Timeular/Timeular-3.8.0.pkg',
                                                        'version': '3.8.0'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '3.8.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Timeular/receipts/Timeular.pkg-receipt-20210213-222436.plist

The following packages were built:
    Identifier        Version  Pkg Path                                                                                        
    ----------        -------  --------                                                                                        
    com.timeular.zei  3.8.0    ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Timeular/Timeular-3.8.0.pkg  
```

