### PR TITLE
Fix MinimumVersion key

### DIFF
--- a/Amazon/AmazonCorretto.download.recipe
+++ b/Amazon/AmazonCorretto.download.recipe
@@ -15,7 +15,7 @@
 		<key>NAME</key>
 		<string>AmazonCorretto%MAJOR_VERSION%</string>
 	</dict>
-	<key>MiniumumVersion</key>
+	<key>MinimumVersion</key>
 	<string>1.0</string>
 	<key>Process</key>
 	<array>

--- a/Amazon/AmazonCorretto.munki.recipe
+++ b/Amazon/AmazonCorretto.munki.recipe
@@ -38,7 +38,7 @@
 			<true/>
 		</dict>
 	</dict>
-	<key>MiniumumVersion</key>
+	<key>MinimumVersion</key>
 	<string>1.0</string>
 	<key>ParentRecipe</key>
 	<string>com.github.n8felton.download.AmazonCorretto</string>

--- a/Microsoft/MicrosoftEdge.download.recipe
+++ b/Microsoft/MicrosoftEdge.download.recipe
@@ -13,7 +13,7 @@
 		<key>CHANNEL</key>
 		<string></string>
 	</dict>
-	<key>MiniumumVersion</key>
+	<key>MinimumVersion</key>
 	<string>1.0</string>
 	<key>Process</key>
 	<array>


### PR DESCRIPTION
A typo was [found and fixed](https://github.com/autopkg/autopkg/commit/983087f63d49c8dbc4dbbd6bb5ced34321c59ac6) in the template AutoPkg uses when the `autopkg new-recipe` command is used. This PR makes the same change in your recipes that are affected by the typo.