### PR TITLE
Move HP printer driver product_number to Input

### DIFF
--- a/HPPrinterDrivers/HPPrinterDrivers.download.recipe
+++ b/HPPrinterDrivers/HPPrinterDrivers.download.recipe
@@ -10,6 +10,8 @@
 	<dict>
 		<key>NAME</key>
 		<string>HPPrinterDrivers</string>
+		<key>PRODUCT_NUMBER</key>
+		<string>E6B70A</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.4</string>
@@ -19,7 +21,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>product_number</key>
-				<string>E6B70A</string>
+				<string>%PRODUCT_NUMBER%</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.n8felton.shared/HPSoftwareInfoProvider</string>


### PR DESCRIPTION
Our product number is `J8A10A`, so I believe the current argument value downloads the wrong package. Migrating this to the Input section of the recipe lets users select which driver package to download and manage any changes to `product_number` on their own schedule. I've retained the default product number value.

Closes #82 