### PR TITLE
Changed linkID's for Edge URLProvider so Universal builds are downloaded

### DIFF
--- a/Microsoft/MicrosoftEdgeURLProvider.py
+++ b/Microsoft/MicrosoftEdgeURLProvider.py
@@ -27,10 +27,10 @@ CHANNEL_LINKID = {
     "Enterprise-Stable": 2093438,
     "Enterprise-Beta": 2093294,
     "Enterprise-Dev": 2093292,
-    "Stable": 2069148,
-    "Beta": 2069439,
-    "Dev": 2069340,
-    "Canary": 2069147,
+    "Stable": 2093504,
+    "Beta": 2099618,
+    "Dev": 2099619,
+    "Canary": 2093293,
 }
 
 


### PR DESCRIPTION
Hi, as discussed on macadmins Slack I've changed the linkID URL's so the Universal builds are downloaded instead of the x86_64 builds. I couldn't find any of the Enterprise linkID's, so they'll still download the x86_64 builds. 

For future reference: I found the linkID's by going to [https://www.microsoft.com/en-us/edge](https://www.microsoft.com/en-us/edge) and [https://www.microsoftedgeinsider.com/en-us/download](https://www.microsoftedgeinsider.com/en-us/download) clicking on "Download for macOS" clinking on "Mac with Apple chip" and then checking the "Accept and download" URL with the developer tools(inspect).

Although it says "Mac with Apple chip" these are Universal builds. I've checked the downloads with `file Microsoft\ Edge.app/Contents/MacOS/Microsoft\ Edge` and the output was:

`Microsoft Edge.app/Contents/MacOS/Microsoft Edge: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64:Mach-O 64-bit executable arm64]
Microsoft Edge.app/Contents/MacOS/Microsoft Edge (for architecture x86_64):	Mach-O 64-bit executable x86_64
Microsoft Edge.app/Contents/MacOS/Microsoft Edge (for architecture arm64):	Mach-O 64-bit executable arm64`

If you consider accepting this pull request, do you think we should create a Readme explaining the above?

Thanks!