### PR TITLE
Fix re-installation loop by creating an Installs Item

### DIFF
--- a/OpenSC/OpenSC.munki.recipe
+++ b/OpenSC/OpenSC.munki.recipe
@@ -59,6 +59,41 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>flat_pkg_path</key>
+				<string>%pathname%/*.pkg</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack</string>
+			</dict>
+			<key>Processor</key>
+			<string>FlatPkgUnpacker</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_payload_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack/OpenSCToken.pkg/Payload</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/payload</string>
+			</dict>
+			<key>Processor</key>
+			<string>PkgPayloadUnpacker</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>faux_root</key>
+				<string>%RECIPE_CACHE_DIR%/payload</string>
+				<key>installs_item_paths</key>
+				<array>
+					<string>/Applications/Utilities/OpenSCTokenApp.app</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiInstallsItemsCreator</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>

--- a/OpenSC/OpenSC.munki.recipe
+++ b/OpenSC/OpenSC.munki.recipe
@@ -91,6 +91,13 @@
 			<key>Processor</key>
 			<string>MunkiInstallsItemsCreator</string>
 		</dict>
+                <dict>
+                        <key>Processor</key>
+                        <string>MunkiPkginfoMerger</string>
+                        <key>Arguments</key>
+                        <dict>
+                        </dict>
+                </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
The current OpenSC.munki.recipe generates a pkgsinfo that leads to continuous installation loop of OpenSC for me. I try to fix that using InstallsItems.