### PR TITLE
CellProfiler no longer stores the version in the filename

### DIFF
--- a/CellProfiler/CellProfiler.download.recipe
+++ b/CellProfiler/CellProfiler.download.recipe
@@ -53,7 +53,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/CellProfiler-*.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/CellProfiler.app</string>
 				<key>requirement</key>
 				<string>identifier "org.cellprofiler.CellProfiler" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "27YQ9U45D9"</string>
 			</dict>


### PR DESCRIPTION
CellProfiler no longer stores the version in the filename

### Output of `autopkg run -vvvv`
```
Paste output here
```
