### PR TITLE
Update Python path in processors to reflect changes in macOS 12.3+

### DIFF
--- a/IntelXDK/IntelXDKInfoProvider.py
+++ b/IntelXDK/IntelXDKInfoProvider.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/local/autopkg/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2016 Nathan Felton (n8felton)

--- a/SharedProcessors/AppleSupportDownloadInfoProvider.py
+++ b/SharedProcessors/AppleSupportDownloadInfoProvider.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/local/autopkg/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2015 Nathan Felton (n8felton)

--- a/SharedProcessors/DistributionInfoProvider.py
+++ b/SharedProcessors/DistributionInfoProvider.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/local/autopkg/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2019 Nathan Felton (n8felton)

--- a/SharedProcessors/HPSoftwareInfoProvider.py
+++ b/SharedProcessors/HPSoftwareInfoProvider.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/local/autopkg/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2016 Nathan Felton (n8felton)

--- a/SharedProcessors/MD5Checksum.py
+++ b/SharedProcessors/MD5Checksum.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/local/autopkg/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2016 Nathan Felton (n8felton)

--- a/SharedProcessors/MunkiGitCommitter.py
+++ b/SharedProcessors/MunkiGitCommitter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/local/autopkg/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2015 Nathan Felton (n8felton)

--- a/SharedProcessors/PkgInfoVersioner.py
+++ b/SharedProcessors/PkgInfoVersioner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/local/autopkg/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2016 Nathan Felton (n8felton)

--- a/SharedProcessors/RemoteFilenameFinder.py
+++ b/SharedProcessors/RemoteFilenameFinder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/local/autopkg/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2016 Nathan Felton (n8felton)

--- a/SharedProcessors/RubyGemInfoProvider.py
+++ b/SharedProcessors/RubyGemInfoProvider.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/local/autopkg/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2016 Nathan Felton (n8felton)

--- a/SharedProcessors/SHA1Checksum.py
+++ b/SharedProcessors/SHA1Checksum.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/local/autopkg/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 Nathan Felton (n8felton)

--- a/SharedProcessors/SHA256Checksum.py
+++ b/SharedProcessors/SHA256Checksum.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/local/autopkg/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 Nathan Felton (n8felton)

--- a/SharedProcessors/SourceForgeBestReleaseURLProvider.py
+++ b/SharedProcessors/SourceForgeBestReleaseURLProvider.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/local/autopkg/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2016 Nathan Felton (n8felton)

--- a/SharedProcessors/URIEncoder.py
+++ b/SharedProcessors/URIEncoder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/local/autopkg/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2020 Nathan Felton (n8felton)

--- a/SharedProcessors/YAML.py
+++ b/SharedProcessors/YAML.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/local/autopkg/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 Nathan Felton (n8felton)


### PR DESCRIPTION
As of macOS Monterey 12.3, the version of Python 2 that shipped with macOS located at `/usr/bin/python` [has been removed](https://developer.apple.com/documentation/macos-release-notes/macos-12_3-release-notes). More context can be found in some posts from Mac admins at the beginning of 2022, aggregated [here](https://scriptingosx.com/2022/03/macos-monterey-12-3-removes-python-2-link-collection/).

Since [version 2.0.2](https://github.com/autopkg/autopkg/releases/tag/v2.0.2), AutoPkg's installer has included its own Python 3 framework, symlinked from `/usr/local/autopkg/python`. This pull request adjusts the "shebang" interpreter paths of processors to replace `/usr/bin/env python` with the AutoPkg Python 3 path.

NOTE: Because AutoPkg processors are imported as modules by AutoPkg and not executed directly, processors' shebang has no effect in normal usage. However: (a) some people execute processors directly during testing, and these tests won't work unless the shebang points to a valid Python 3, and (b) having instances of `/usr/bin/env python` in the codebase could lead to confusion for people not deeply familiar with processor behavior.

Thank you for your consideration!