### PR TITLE
Overhauling HPPrinterDrivers

### DIFF
--- a/HPPrinterDrivers/HPPrinterDrivers.download.recipe
+++ b/HPPrinterDrivers/HPPrinterDrivers.download.recipe
@@ -10,8 +10,12 @@
 	<dict>
 		<key>NAME</key>
 		<string>HPPrinterDrivers</string>
-		<key>PRODUCT_NUMBER</key>
-		<string>E6B70A</string>
+		<key>HP_QUERY_TYPE</key>
+		<string>ModelName</string>
+		<key>HP_QUERY</key>
+		<string>HP Color LaserJet Pro M453-4</string>
+		<key>OPERATING_SYSTEM</key>
+		<string>macOS 12.0</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.4</string>

--- a/SharedProcessors/HPSoftwareInfoProvider.py
+++ b/SharedProcessors/HPSoftwareInfoProvider.py
@@ -33,9 +33,7 @@ HP_BASE_URL = (
     "cc={country_code}"
 )
 
-HP_OPTIONAL_QUERY = (
-    "&client=hp-quick-start"
-)
+HP_OPTIONAL_QUERY = "&client=hp-quick-start"
 
 
 class HPSoftwareInfoProvider(URLGetter):

--- a/SharedProcessors/HPSoftwareInfoProvider.py
+++ b/SharedProcessors/HPSoftwareInfoProvider.py
@@ -18,7 +18,7 @@
 
 import json
 
-from autopkglib import URLGetter
+from autopkglib import ProcessorError, URLGetter
 from pkg_resources import packaging
 from urllib.parse import urlparse, quote
 
@@ -132,6 +132,7 @@ class HPSoftwareInfoProvider(URLGetter):
         self.output(software_list, 3)
         # Create a packaging.version.Version object with all zeroes.
         greatest_version = packaging.version.parse("0.0.0.0")
+        recent_software = None
         for software in software_list:
             # Skip any key that isn't "ESSENTIAL-REQUIRED"
             if software["Type"] != "ESSENTIAL-REQUIRED":
@@ -142,6 +143,8 @@ class HPSoftwareInfoProvider(URLGetter):
                 greatest_version = software_version
                 recent_software = software
 
+        if recent_software is None:
+            raise ProcessorError("Unable to find valid version of HP software")
         parsed_url = urlparse(recent_software["FtpURL"])
 
         # The HP ftp server rejects FTP requests now.

--- a/SharedProcessors/HPSoftwareInfoProvider.py
+++ b/SharedProcessors/HPSoftwareInfoProvider.py
@@ -18,51 +18,68 @@
 
 import json
 
-from autopkglib import Processor, ProcessorError, URLGetter
+from autopkglib import URLGetter
+from pkg_resources import packaging
+from urllib.parse import urlparse, quote
 
-try:
-    from urllib.parse import quote  # For Python 3
-except ImportError:
-    from urllib2 import quote  # For Python 2
 
 __all__ = ["HPSoftwareInfoProvider"]
 
 HP_BASE_URL = (
     "https://h20614.www2.hp.com/ediags/solutions/software/v3?"
-    "ProductNumber={product_number}&"
-    "OS={os}&"
+    "{hp_query_type}={hp_query}&"
+    "OS={operating_system}&"
     "lc={lang_code}&"
     "cc={country_code}"
+)
+
+HP_OPTIONAL_QUERY = (
+    "&client=hp-quick-start"
 )
 
 
 class HPSoftwareInfoProvider(URLGetter):
     """Determines the ESSENTIAL-REQUIRED software necessary for a given
-    product_number.
+    hp_query.
 
     Returns the URL, version and description of the software.
     """
 
     description = __doc__
     input_variables = {
-        "product_number": {
+        "HP_QUERY_TYPE": {
             "required": True,
+            "default": "ModelName",
             "description": (
-                "HP Product Number of device that requires software. "
-                "Typically 6 alphanumeric characters, e.g. E6B70A"
+                "Query type for specific product. For legacy products, this "
+                "is ProductNumber, for future products, this is ModelName. "
+                "Default is ModelName."
             ),
         },
-        "os": {
-            "required": False,
-            "default": "Mac OS X 10.11",
-            "description": "The OS you want to search for",
+        "HP_QUERY": {
+            "required": True,
+            "default": "HP Color LaserJet Pro M453-4",
+            "description": (
+                "HP Product Number or Model Name of device that requires "
+                "software. For ProductNumber, this is typically 6 "
+                "alphanumeric characters, e.g. E6B70A. For ModelName, this "
+                "is the full product name, e.g. HP Color LaserJet Pro M453-4."
+            ),
         },
-        "lang_code": {
+        "OPERATING_SYSTEM": {
+            "required": True,
+            "default": "macOS 12.0",
+            "description": (
+                "Full name of the OS you want to search for, "
+                "e.g. macOS 12.0. Default is macOS 12.0"
+            ),
+        },
+        "LANG_CODE": {
             "required": False,
             "default": "en",
             "description": "ISO 639-1 code for preferred language",
         },
-        "country_code": {
+        "COUNTRY_CODE": {
             "required": False,
             "default": "us",
             "description": "ISO 3166-1 alpha-2 code for preferred country",
@@ -84,35 +101,61 @@ class HPSoftwareInfoProvider(URLGetter):
         """Main process."""
 
         # Capture input variables
-        product_number = self.env.get("product_number")
-        os = quote(self.env.get("os", "Mac OS X 10.11"))
-        lang_code = self.env.get("lang_code", "en")
-        country_code = self.env.get("country_code", "us")
+        hp_query_type = self.env.get("HP_QUERY_TYPE", "ModelName")
+        # Fallback to PRODUCT_NUMBER for legacy support.
+        hp_query = (
+            self.env.get("HP_QUERY") or self.env.get("PRODUCT_NUMBER")
+        ).replace(" ", "+")
+        operating_system = quote(
+            self.env.get("OPERATING_SYSTEM", "macOS 12.0")
+        )
+        lang_code = self.env.get("LANG_CODE", "en")
+        country_code = self.env.get("COUNTRY_CODE", "us")
 
         # Determine software URL
         software_url = HP_BASE_URL.format(
-            product_number=product_number,
-            os=os,
+            hp_query_type=hp_query_type,
+            hp_query=hp_query,
+            operating_system=operating_system,
             lang_code=lang_code,
             country_code=country_code,
         )
-        self.output("Software URL: {software_url}".format(software_url=software_url), 2)
+        # Add the additional optional query string to the URL when searching
+        # for ModelName
+        if hp_query_type == "ModelName":
+            software_url = software_url + HP_OPTIONAL_QUERY
+
+        self.output(f"Software URL: {software_url}", 2)
 
         # Get software list and iterate through it
         software_list = self.get_hp_software_list(software_url)
         self.output(software_list, 3)
+        # Create a packaging.version.Version object with all zeroes.
+        greatest_version = packaging.version.parse("0.0.0.0")
         for software in software_list:
-            if software["Type"] == "ESSENTIAL-REQUIRED":
-                self.env["url"] = software["FtpURL"]
-                self.output(software["FtpURL"])
-                self.env["version"] = software["Version"]
-                self.env["description"] = software["Description"]
-                # We're hoping there is only one ESSENTIAL-REQUIRED
-                # but if there are multiple, we should only return the first.
-                # If this becomes a problem, we'll need to test on some of the
-                # other keys that are available.
-                break
-        # essential_required_software = software_list
+            # Skip any key that isn't "ESSENTIAL-REQUIRED"
+            if software["Type"] != "ESSENTIAL-REQUIRED":
+                continue
+            software_version = packaging.version.parse(software["Version"])
+            # Find the greatest version of the HP Essentials.
+            if greatest_version < software_version:
+                greatest_version = software_version
+                recent_software = software
+
+        parsed_url = urlparse(recent_software["FtpURL"])
+
+        # The HP ftp server rejects FTP requests now.
+        if parsed_url.scheme == "ftp":
+            # urllib.parse.ParseResult is a subclass of namedtuple. So it
+            # is iterable.
+            flat_url = "https://" + "".join([_u for _u in parsed_url[1:]])
+        else:
+            flat_url = parsed_url.geturl()
+
+        self.env["url"] = flat_url
+        self.output(flat_url)
+        self.env["version"] = recent_software["Version"]
+        self.env["description"] = recent_software["Description"]
 
 
 if __name__ == "__main__":

--- a/SharedProcessors/HPSoftwareInfoProvider.py
+++ b/SharedProcessors/HPSoftwareInfoProvider.py
@@ -101,14 +101,15 @@ class HPSoftwareInfoProvider(URLGetter):
         """Main process."""
 
         # Capture input variables
-        hp_query_type = self.env.get("HP_QUERY_TYPE", "ModelName")
         # Fallback to PRODUCT_NUMBER for legacy support.
-        hp_query = (
-            self.env.get("HP_QUERY") or self.env.get("PRODUCT_NUMBER")
-        ).replace(" ", "+")
-        operating_system = quote(
-            self.env.get("OPERATING_SYSTEM", "macOS 12.0")
-        )
+        # OPERATING_SYSTEM will probably need to be set to 'Mac OS X 10.11'
+        if self.env.get("PRODUCT_NUMBER"):
+            hp_query_type = "ProductNumber"
+            hp_query = (self.env.get("PRODUCT_NUMBER")).replace(" ", "+")
+        else:
+            hp_query_type = self.env.get("HP_QUERY_TYPE", "ModelName")
+            hp_query = (self.env.get("HP_QUERY")).replace(" ", "+")
+        operating_system = quote(self.env.get("OPERATING_SYSTEM"))
         lang_code = self.env.get("LANG_CODE", "en")
         country_code = self.env.get("COUNTRY_CODE", "us")
 


### PR DESCRIPTION
Due to some changes on HP's side, the HPPrinterDrivers recipe is not functioning. I have made some changes in order to fix those errors and provide greater flexibility in the recipe.

### HPSoftwareInfoProvider.py

* Added additional imports
* Removed Python 2 workaround
* Modified HP_BASE_URL to also have a key for the query type
* Added optional query
* Fixed references to case-sensitive environment variables
* Added new HP_QUERY_TYPE environment variable
* Modified "OS" to be `operating_system` to prevent conflicts with `os` built-in.
* Changed "product_number" to "HP_QUERY" as it's ProductNumber sometimes and ModelName otherwise
* Used the packaging versioner to parse the version strings and figure out which is higher. It is *not* always the first one in the new schema.
* Verified if the discovered url begins with `ftp` and modify it to use `https` since the HP FTP server rejects FTP requests now. Even the HP Easy Admin client tries HTTPS first.

### HPPrinterDrivers.download.recipe
* Modified to use the above changes.

### Output of `autopkg run -vvvv`
```
% autopkg run HPPrinterDrivers.download -vvvv
Processing HPPrinterDrivers.download...
WARNING: HPPrinterDrivers.download is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
{'AUTOPKG_VERSION': '2.7',
 'HP_QUERY': 'HP Color LaserJet Pro M453-4',
 'HP_QUERY_TYPE': 'ModelName',
 'NAME': 'HPPrinterDrivers',
 'OPERATING_SYSTEM': 'macOS 12.0',
 'PARENT_RECIPES': [],
 'RECIPE_CACHE_DIR': '/Users/username/Library/AutoPkg/Cache/com.github.n8felton.download.HPPrinterDrivers',
 'RECIPE_DIR': '/Users/username/gitlab/n8felton-recipes/HPPrinterDrivers',
 'RECIPE_OVERRIDE_DIRS': ['~/Library/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/username/gitlab/n8felton-recipes/HPPrinterDrivers/HPPrinterDrivers.download.recipe',
 'RECIPE_REPOS': {'/Users/username/Library/AutoPkg/RecipeRepos/com.github.autopkg.macvfx-recipes': {'URL': 'https://github.com/autopkg/macvfx-recipes'},
                  '/Users/username/Library/AutoPkg/RecipeRepos/com.github.autopkg.n8felton-recipes': {'URL': 'https://github.com/autopkg/n8felton-recipes'},
                  '/Users/username/Library/AutoPkg/RecipeRepos/com.github.autopkg.primalcurve-recipes': {'URL': 'https://github.com/autopkg/primalcurve-recipes'}},
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes',
                        '/Users/username/Library/AutoPkg/RecipeRepos/com.github.autopkg.macvfx-recipes',
                        '/Users/username/Library/AutoPkg/RecipeRepos/com.github.autopkg.n8felton-recipes',
                        '/Users/username/Library/AutoPkg/RecipeRepos/com.github.autopkg.primalcurve-recipes'],
 'verbose': 4}
com.github.n8felton.shared/HPSoftwareInfoProvider
Use of undefined key in variable substitution: 'PRODUCT_NUMBER'
{'Input': {'HP_QUERY': 'HP Color LaserJet Pro M453-4',
           'HP_QUERY_TYPE': 'ModelName',
           'OPERATING_SYSTEM': 'macOS 12.0'}}
HPSoftwareInfoProvider: No value supplied for LANG_CODE, setting default value of: en
HPSoftwareInfoProvider: No value supplied for COUNTRY_CODE, setting default value of: us
HPSoftwareInfoProvider: Software URL: https://h20614.www2.hp.com/ediags/solutions/software/v3?ModelName=HP+Color+LaserJet+Pro+M453-4&OS=macOS%2012.0&lc=en&cc=us&client=hp-quick-start
HPSoftwareInfoProvider: Curl command: ['/usr/bin/curl', '--compressed', '--location', 'https://h20614.www2.hp.com/ediags/solutions/software/v3?ModelName=HP+Color+LaserJet+Pro+M453-4&OS=macOS%2012.0&lc=en&cc=us&client=hp-quick-start']
HPSoftwareInfoProvider: [{'SoftwareId': 'mp-280205-1', 'PID': None, 'ProductNumber': None, 'ModelName': 'HP Color LaserJet Pro M453-4', 'lc': 'en', 'cc': 'us', 'Type': 'ESSENTIAL-REQUIRED', 'Identifier': 'com.hp.pkg.swls.printer-essentials-UniPS.version', 'IdentifierType': 'OSXPackageMakerPackage', 'Version': '6.0.0.6', 'MinVersion': None, 'Function': 'PSF', 'FtpURL': 'ftp://ftp.hp.com/pub/softlib/software12/HP_Quick_Start/osx/Installations/Essentials/macOS12/hp-printer-essentials-UniPS-6_0_0_6.pkg', 'HelpURL': None, 'Title': 'Essential Software', 'Description': 'Installs genuine HP Drivers and HP Utility - essential software for using the features of your HP product.'}, {'SoftwareId': 'mp-300092-1', 'PID': None, 'ProductNumber': None, 'ModelName': 'HP Color LaserJet Pro M453-4', 'lc': 'en', 'cc': 'us', 'Type': 'ESSENTIAL-REQUIRED', 'Identifier': 'com.hp.pkg.swls.printer-essentials-UniPS.version', 'IdentifierType': 'OSXPackageMakerPackage', 'Version': '6.1.0.1', 'MinVersion': None, 'Function': 'PSF', 'FtpURL': 'ftp://ftp.hp.com/pub/softlib/software12/HP_Quick_Start/osx/Installations/Essentials/macOS13/hp-printer-essentials-UniPS-6_1_0_1.pkg', 'HelpURL': None, 'Title': 'Essential Software', 'Description': 'Installs genuine HP Drivers and HP Utility - essential software for using the features of your HP product.'}]
HPSoftwareInfoProvider: https://ftp.hp.com/pub/softlib/software12/HP_Quick_Start/osx/Installations/Essentials/macOS13/hp-printer-essentials-UniPS-6_1_0_1.pkg
{'Output': {'description': 'Installs genuine HP Drivers and HP Utility - '
                           'essential software for using the features of your '
                           'HP product.',
            'url': 'https://ftp.hp.com/pub/softlib/software12/HP_Quick_Start/osx/Installations/Essentials/macOS13/hp-printer-essentials-UniPS-6_1_0_1.pkg',
            'version': '6.1.0.1'}}
URLDownloader
{'Input': {'url': 'https://ftp.hp.com/pub/softlib/software12/HP_Quick_Start/osx/Installations/Essentials/macOS13/hp-printer-essentials-UniPS-6_1_0_1.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Curl command: ['/usr/bin/curl', '--silent', '--show-error', '--no-buffer', '--dump-header', '-', '--speed-time', '30', '--location', '--url', 'https://ftp.hp.com/pub/softlib/software12/HP_Quick_Start/osx/Installations/Essentials/macOS13/hp-printer-essentials-UniPS-6_1_0_1.pkg', '--fail', '--output', '/Users/username/Library/AutoPkg/Cache/com.github.n8felton.download.HPPrinterDrivers/downloads/tmp67tazlrh']
URLDownloader: Storing new Last-Modified header: Fri, 04 Nov 2022 17:08:55 GMT
URLDownloader: Storing new ETag header: "19877c99ceb90212990d6730f0d23d77-92"
URLDownloader: Downloaded /Users/username/Library/AutoPkg/Cache/com.github.n8felton.download.HPPrinterDrivers/downloads/hp-printer-essentials-UniPS-6_1_0_1.pkg
{'Output': {'download_changed': True,
            'etag': '"19877c99ceb90212990d6730f0d23d77-92"',
            'last_modified': 'Fri, 04 Nov 2022 17:08:55 GMT',
            'pathname': '/Users/username/Library/AutoPkg/Cache/com.github.n8felton.download.HPPrinterDrivers/downloads/hp-printer-essentials-UniPS-6_1_0_1.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/username/Library/AutoPkg/Cache/com.github.n8felton.download.HPPrinterDrivers/downloads/hp-printer-essentials-UniPS-6_1_0_1.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: HP Inc. '
                                        '(6HB5Y2QTA3)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/username/Library/AutoPkg/Cache/com.github.n8felton.download.HPPrinterDrivers/downloads/hp-printer-essentials-UniPS-6_1_0_1.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "hp-printer-essentials-UniPS-6_1_0_1.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2022-10-13 07:42:40 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: HP Inc. (6HB5Y2QTA3)
CodeSignatureVerifier:        Expires: 2025-02-10 20:05:07 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            56 6A 5A 62 A7 30 B6 F7 33 F5 D4 DD 5F 57 0E A4 D2 B1 6F B1 F4 67
CodeSignatureVerifier:            24 3A 13 E3 3D E6 C9 AA 15 C6
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
{'AUTOPKG_VERSION': '2.7',
 'CHECK_FILESIZE_ONLY': False,
 'COUNTRY_CODE': 'us',
 'HP_QUERY': 'HP Color LaserJet Pro M453-4',
 'HP_QUERY_TYPE': 'ModelName',
 'LANG_CODE': 'en',
 'NAME': 'HPPrinterDrivers',
 'OPERATING_SYSTEM': 'macOS 12.0',
 'PARENT_RECIPES': [],
 'RECIPE_CACHE_DIR': '/Users/username/Library/AutoPkg/Cache/com.github.n8felton.download.HPPrinterDrivers',
 'RECIPE_DIR': '/Users/username/gitlab/n8felton-recipes/HPPrinterDrivers',
 'RECIPE_OVERRIDE_DIRS': ['~/Library/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/username/gitlab/n8felton-recipes/HPPrinterDrivers/HPPrinterDrivers.download.recipe',
 'RECIPE_REPOS': {'/Users/username/Library/AutoPkg/RecipeRepos/com.github.autopkg.macvfx-recipes': {'URL': 'https://github.com/autopkg/macvfx-recipes'},
                  '/Users/username/Library/AutoPkg/RecipeRepos/com.github.autopkg.n8felton-recipes': {'URL': 'https://github.com/autopkg/n8felton-recipes'},
                  '/Users/username/Library/AutoPkg/RecipeRepos/com.github.autopkg.primalcurve-recipes': {'URL': 'https://github.com/autopkg/primalcurve-recipes'}},
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes',
                        '/Users/username/Library/AutoPkg/RecipeRepos/com.github.autopkg.macvfx-recipes',
                        '/Users/username/Library/AutoPkg/RecipeRepos/com.github.autopkg.n8felton-recipes',
                        '/Users/username/Library/AutoPkg/RecipeRepos/com.github.autopkg.primalcurve-recipes'],
 'description': 'Installs genuine HP Drivers and HP Utility - essential '
                'software for using the features of your HP product.',
 'download_changed': True,
 'etag': '"19877c99ceb90212990d6730f0d23d77-92"',
 'expected_authority_names': ['Developer ID Installer: HP Inc. (6HB5Y2QTA3)',
                              'Developer ID Certification Authority',
                              'Apple Root CA'],
 'input_path': '/Users/username/Library/AutoPkg/Cache/com.github.n8felton.download.HPPrinterDrivers/downloads/hp-printer-essentials-UniPS-6_1_0_1.pkg',
 'last_modified': 'Fri, 04 Nov 2022 17:08:55 GMT',
 'pathname': '/Users/username/Library/AutoPkg/Cache/com.github.n8felton.download.HPPrinterDrivers/downloads/hp-printer-essentials-UniPS-6_1_0_1.pkg',
 'prefetch_filename': False,
 'product_number': '%PRODUCT_NUMBER%',
 'url': 'https://ftp.hp.com/pub/softlib/software12/HP_Quick_Start/osx/Installations/Essentials/macOS13/hp-printer-essentials-UniPS-6_1_0_1.pkg',
 'url_downloader_summary_result': {'data': {'download_path': '/Users/username/Library/AutoPkg/Cache/com.github.n8felton.download.HPPrinterDrivers/downloads/hp-printer-essentials-UniPS-6_1_0_1.pkg'},
                                   'summary_text': 'The following new items '
                                                   'were downloaded:'},
 'verbose': 4,
 'version': '6.1.0.1'}
Receipt written to /Users/username/Library/AutoPkg/Cache/com.github.n8felton.download.HPPrinterDrivers/receipts/HPPrinterDrivers-receipt-20221109-161807.plist

The following new items were downloaded:
    Download Path
    -------------
    /Users/username/Library/AutoPkg/Cache/com.github.n8felton.download.HPPrinterDrivers/downloads/hp-printer-essentials-UniPS-6_1_0_1.pkg
```
