### PR TITLE
Update MicrosoftEdge.munki.recipe

### DIFF
--- a/Microsoft/MicrosoftEdge.munki.recipe
+++ b/Microsoft/MicrosoftEdge.munki.recipe
@@ -3,11 +3,15 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of Microsoft Edge for the specified branch.</string>
+    <string>Downloads the latest version of Microsoft Edge for the specified branch.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.n8felton.munki.MicrosoftEdge</string>
     <key>Input</key>
     <dict>
+        <key>DERIVE_MIN_OS</key>
+        <string>YES</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
         <key>MUNKI_CATEGORY</key>
@@ -37,7 +41,7 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>2.7</string>
     <key>ParentRecipe</key>
     <string>com.github.n8felton.download.MicrosoftEdge</string>
     <key>Process</key>
@@ -123,6 +127,8 @@
                 </array>
                 <key>version_comparison_key</key>
                 <string>CFBundleVersion</string>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Hi, @n8felton 

The MicrosoftEdge Munki recipe currently doesn't set the `minimum_os_version` from the App's info.plist, and as such a default value of 10.5.0 is being set.

This PR adds in support for the new `derive_minimum_os_version` key in the `MunkiInstallsItemsCreator` processor. With this set the min_os_version becomes 10.13

This change requires AutoPkg version 2.7 or higher, if compatibility with older versions of AutoPkg is needed, the same result could be achieved with something like below.

```
        <dict>
            <key>Arguments</key>
            <dict>
                <key>info_path</key>
                <string>%RECIPE_CACHE_DIR%/Applications/APP_NAME.app</string>
                <key>plist_keys</key>
                <dict>
                    <key>LSMinimumSystemVersion</key>
                    <string>min_os_ver</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>PlistReader</string>
        </dict>
        <dict>
             <key>Arguments</key>
             <dict>
                <key>additional_pkginfo</key>
                <dict>
                    <key>minimum_os_version</key>
                    <string>%min_os_ver%</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>MunkiPkginfoMerger</string>
        </dict>
```

Output from a successful verbose run:

```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/n8felton-recipes/Microsoft/MicrosoftEdge.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/n8felton-recipes/Microsoft/MicrosoftEdge.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/n8felton-recipes/Microsoft/MicrosoftEdge.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
MicrosoftEdgeURLProvider
MicrosoftEdgeURLProvider: Available channels: dict_keys(['Enterprise-Stable', 'Enterprise-Beta', 'Enterprise-Dev', 'Stable', 'Beta', 'Dev', 'Canary'])
MicrosoftEdgeURLProvider: Using Stable channel
com.github.n8felton.shared/RemoteFilenameFinder
URLDownloader
URLDownloader: Storing new Last-Modified header: Fri, 16 Dec 2022 00:51:49 GMT
URLDownloader: Storing new ETag header: "0x18C4B4301FBA727E1FD11EA952F2EE989228A12B422CB589C207A30F0E790C12"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.n8felton.munki.MicrosoftEdge/downloads/MicrosoftEdge-108.0.1462.54.pkg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "MicrosoftEdge-108.0.1462.54.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2022-12-15 20:29:53 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Microsoft Corporation (UBF8T346G9)
CodeSignatureVerifier:        Expires: 2023-05-16 04:46:41 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            6A 66 CD 33 B5 5B 9C 14 86 02 29 09 DB 7E 00 85 53 11 29 6B CE 11 
CodeSignatureVerifier:            9F 2A 93 5C 69 BF 56 3A 79 82
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.n8felton.munki.MicrosoftEdge/downloads/MicrosoftEdge-108.0.1462.54.pkg to /Users/paul/Library/AutoPkg/Cache/com.github.n8felton.munki.MicrosoftEdge/unpack
PkgRootCreator
PkgRootCreator: Created /Users/paul/Library/AutoPkg/Cache/com.github.n8felton.munki.MicrosoftEdge/pkgroot
PkgRootCreator: Created /Users/paul/Library/AutoPkg/Cache/com.github.n8felton.munki.MicrosoftEdge/pkgroot/Applications
FileFinder
FileFinder: Found file match: '/Users/paul/Library/AutoPkg/Cache/com.github.n8felton.munki.MicrosoftEdge/unpack/MicrosoftEdge-108.0.1462.54.pkg/' from globbed '/Users/paul/Library/AutoPkg/Cache/com.github.n8felton.munki.MicrosoftEdge/unpack/MicrosoftEdge*.pkg/'
FileFinder: Basename match: 'MicrosoftEdge-108.0.1462.54.pkg'
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.n8felton.munki.MicrosoftEdge/unpack/MicrosoftEdge-108.0.1462.54.pkg//Payload to /Users/paul/Library/AutoPkg/Cache/com.github.n8felton.munki.MicrosoftEdge/pkgroot/Applications/
Versioner
Versioner: Found version 108.1462.22121554 in file /Users/paul/Library/AutoPkg/Cache/com.github.n8felton.munki.MicrosoftEdge/pkgroot/Applications/Microsoft Edge.app/Contents/Info.plist
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '108.1462.22121554'} into pkginfo
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/Microsoft Edge.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.13
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '108.1462.22121554', 'installs': [{'CFBundleIdentifier': 'com.microsoft.edgemac', 'CFBundleName': 'Microsoft Edge', 'CFBundleShortVersionString': '108.0.1462.54', 'CFBundleVersion': '108.1462.22121554', 'minosversion': '10.13', 'path': '/Applications/Microsoft Edge.app', 'type': 'application', 'version_comparison_key': 'CFBundleVersion'}], 'minimum_os_version': '10.13'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/MicrosoftEdge/MicrosoftEdge-108.1462.22121554.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/MicrosoftEdge/MicrosoftEdge-108.0.1462.54-108.1462.22121554.pkg
PathDeleter
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.n8felton.munki.MicrosoftEdge/pkgroot
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.n8felton.munki.MicrosoftEdge/unpack
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.n8felton.munki.MicrosoftEdge/receipts/MicrosoftEdge.munki-receipt-20221223-164042.plist

The following new items were downloaded:
    Download Path                                                                                                        
    -------------                                                                                                        
    /Users/paul/Library/AutoPkg/Cache/com.github.n8felton.munki.MicrosoftEdge/downloads/MicrosoftEdge-108.0.1462.54.pkg  

The following new items were imported into Munki:
    Name           Version            Catalogs  Pkginfo Path                                              Pkg Repo Path                                                         Icon Repo Path  
    ----           -------            --------  ------------                                              -------------                                                         --------------  
    MicrosoftEdge  108.1462.22121554  testing   apps/MicrosoftEdge/MicrosoftEdge-108.1462.22121554.plist  apps/MicrosoftEdge/MicrosoftEdge-108.0.1462.54-108.1462.22121554.pkg  
```