### PR TITLE
Update Tidal.download.recipe

### DIFF
--- a/Tidal/Tidal.download.recipe
+++ b/Tidal/Tidal.download.recipe
@@ -21,7 +21,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://download.tidal.com/desktop/TIDAL.dmg</string>
+				<string>https://download.tidal.com/desktop/TIDAL.x64.dmg</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Download URL(https://download.tidal.com/desktop/TIDAL.dmg) downloads only version 2.30, when latest ist 2.34.2.

Changed download URL to: https://download.tidal.com/desktop/TIDAL.x64.dmg - which will download the latest Intel version.

If you want to add URL for Apple Silicon version, that is: https://download.tidal.com/desktop/TIDAL.arm64.dmg  - we use only Intel version with Rosetta.

### Output of `autopkg run -vvvv`
```
Paste output here
```
