### PR TITLE
Update MAMP Recipes with Architecture Support

### DIFF
--- a/MAMP/MAMP.download.recipe
+++ b/MAMP/MAMP.download.recipe
@@ -3,7 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of MAMP.</string>
+	<string>Downloads the latest version of MAMP.
+
+ARCH_TYPE is "Intel-x86" or "M1-arm"</string>
 	<key>Identifier</key>
 	<string>com.github.n8felton.download.MAMP</string>
 	<key>Input</key>
@@ -14,6 +16,8 @@
 		<string>MAMP</string>
 		<key>SEARCH_URL</key>
 		<string>https://www.mamp.info/en/downloads</string>
+		<key>ARCH_TYPE</key>
+		<string>Intel-x86</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -27,7 +31,7 @@
 				<key>url</key>
 				<string>%SEARCH_URL%</string>
 				<key>re_pattern</key>
-				<string>(?P&lt;filename&gt;MAMP_MAMP_PRO_(?P&lt;version&gt;((?:(\d+)\.)?(?:(\d+)\.)?(\*|\d+)))\-Intel-x86).pkg"</string>
+				<string>(?P&lt;filename&gt;MAMP_MAMP_PRO_(?P&lt;version&gt;((?:(\d+)\.)?(?:(\d+)\.)?(\*|\d+)))\-%ARCH_TYPE%).pkg"</string>
 			</dict>
 		</dict>
 		<dict>

--- a/MAMP/MAMP.munki.recipe
+++ b/MAMP/MAMP.munki.recipe
@@ -73,7 +73,20 @@ SUPPORTED_ARCH can be left empty, "x86_64" or "arm64".</string>
 				<key>pkg_payload_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpacked/MAMP_PRO.pkg/Payload</string>
 				<key>purge_destination</key>
-				<true></true>
+				<false/>
+			</dict>
+			<key>Processor</key>
+			<string>PkgPayloadUnpacker</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/Applications</string>
+				<key>pkg_payload_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpacked/MAMP.pkg/Payload</string>
+				<key>purge_destination</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>PkgPayloadUnpacker</string>
@@ -85,6 +98,7 @@ SUPPORTED_ARCH can be left empty, "x86_64" or "arm64".</string>
 				<string>%RECIPE_CACHE_DIR%</string>
 				<key>installs_item_paths</key>
 				<array>
+					<string>/Applications/MAMP/MAMP.app</string>
 					<string>/Applications/MAMP PRO.app</string>
 				</array>
 				<key>derive_minimum_os_version</key>
@@ -113,7 +127,8 @@ SUPPORTED_ARCH can be left empty, "x86_64" or "arm64".</string>
 			<dict>
 				<key>path_list</key>
 				<array>
-					<string>%RECIPE_CACHE_DIR%/unpacked</string>
+					<string>%RECIPE_CACHE_DIR%/unpacked/</string>
+					<string>%RECIPE_CACHE_DIR%/Applications/</string>
 				</array>
 			</dict>
 			<key>Processor</key>

--- a/MAMP/MAMP.munki.recipe
+++ b/MAMP/MAMP.munki.recipe
@@ -3,7 +3,11 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of MAMP and imports it into Munki.</string>
+	<string>Downloads the latest version of MAMP and imports it into Munki.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator.
+
+SUPPORTED_ARCH can be left empty, "x86_64" or "arm64".</string>
 	<key>Identifier</key>
 	<string>com.github.n8felton.munki.MAMP</string>
 	<key>Input</key>
@@ -14,6 +18,10 @@
 		<string>apps/%NAME%</string>
 		<key>NAME</key>
 		<string>MAMP</string>
+		<key>SUPPORTED_ARCH</key>
+		<string>x86_64</string>
+		<key>DERIVE_MIN_OS</key>
+		<string>YES</string>
 		<key>pkginfo</key>
 		<dict>
 			<key>catalogs</key>
@@ -28,8 +36,10 @@
 			<string>Appsolute GmbH</string>
 			<key>display_name</key>
 			<string>MAMP</string>
-			<key>minimum_os_version</key>
-			<string>10.6.8</string>
+			<key>supported_architectures</key>
+			<array>
+				<string>%SUPPORTED_ARCH%</string>
+			</array>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>
@@ -37,11 +47,56 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.1</string>
+	<string>2.7</string>
 	<key>ParentRecipe</key>
 	<string>com.github.n8felton.download.MAMP</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpacked</string>
+				<key>flat_pkg_path</key>
+				<string>%pathname%</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+			<key>Processor</key>
+			<string>FlatPkgUnpacker</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/Applications</string>
+				<key>pkg_payload_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpacked/MAMP_PRO.pkg/Payload</string>
+				<key>purge_destination</key>
+				<true></true>
+			</dict>
+			<key>Processor</key>
+			<string>PkgPayloadUnpacker</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>faux_root</key>
+				<string>%RECIPE_CACHE_DIR%</string>
+				<key>installs_item_paths</key>
+				<array>
+					<string>/Applications/MAMP PRO.app</string>
+				</array>
+				<key>derive_minimum_os_version</key>
+				<string>%DERIVE_MIN_OS%</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiInstallsItemsCreator</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
@@ -52,6 +107,17 @@
 			</dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/unpacked</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
Hi, @n8felton 

This PR adds in support for downloading architecture specific versions of MAMP. 

I've also updated the Munki recipe so that it creates an Installs Array for the MAMP PRO App, and sets the minimum os version from the Apps info.plist. 

### Output of `autopkg run -v` for the arm64 version.
```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/n8felton-recipes/MAMP/MAMP.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/n8felton-recipes/MAMP/MAMP.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/n8felton-recipes/MAMP/MAMP.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (filename): MAMP_MAMP_PRO_6.8-M1-arm
URLTextSearcher: Found matching text (version): 6.8
URLTextSearcher: Found matching text (match): MAMP_MAMP_PRO_6.8-M1-arm
URLDownloader
URLDownloader: File size returned by webserver matches that of the cached file: 448650428 bytes
URLDownloader: WARNING: Matching a download by filesize is a fallback mechanism that does not guarantee that a build is unchanged.
URLDownloader: Using existing /Users/paul/Library/AutoPkg/Cache/com.github.n8felton.munki.MAMP/downloads/MAMP_MAMP_PRO_6.8-M1-arm-6.8.pkg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "MAMP_MAMP_PRO_6.8-M1-arm-6.8.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2023-01-26 18:11:11 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: MAMP GmbH (5KCB5KHK77)
CodeSignatureVerifier:        Expires: 2024-01-25 09:20:56 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F0 79 14 4F EE 5E 63 2E 38 87 F7 74 0C C9 29 71 F6 4E 28 CC B9 04 
CodeSignatureVerifier:            94 7D 9B EA 20 EF A6 4D 6D E2
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.n8felton.munki.MAMP/downloads/MAMP_MAMP_PRO_6.8-M1-arm-6.8.pkg to /Users/paul/Library/AutoPkg/Cache/com.github.n8felton.munki.MAMP/unpacked
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.n8felton.munki.MAMP/unpacked/MAMP_PRO.pkg/Payload to /Users/paul/Library/AutoPkg/Cache/com.github.n8felton.munki.MAMP/Applications
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/MAMP PRO.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.12.0
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'de.appsolute.mamppro', 'CFBundleName': 'MAMP PRO', 'CFBundleShortVersionString': '6.8', 'CFBundleVersion': '34110', 'minosversion': '10.12.0', 'path': '/Applications/MAMP PRO.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '10.12.0'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/MAMP/MAMP-6.8.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/MAMP/MAMP_MAMP_PRO_6.8-M1-arm-6.8.pkg
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.n8felton.munki.MAMP/receipts/MAMP.munki-receipt-20230706-175832.plist

The following new items were imported into Munki:
    Name  Version  Catalogs  Pkginfo Path              Pkg Repo Path                               Icon Repo Path  
    ----  -------  --------  ------------              -------------                               --------------  
    MAMP  6.8      testing   apps/MAMP/MAMP-6.8.plist  apps/MAMP/MAMP_MAMP_PRO_6.8-M1-arm-6.8.pkg
```
### Output of `autopkg run -v` for the x86_64 version.
```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/n8felton-recipes/MAMP/MAMP.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/n8felton-recipes/MAMP/MAMP.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/n8felton-recipes/MAMP/MAMP.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (filename): MAMP_MAMP_PRO_6.8-Intel-x86
URLTextSearcher: Found matching text (version): 6.8
URLTextSearcher: Found matching text (match): MAMP_MAMP_PRO_6.8-Intel-x86
URLDownloader
URLDownloader: File size returned by webserver matches that of the cached file: 482618131 bytes
URLDownloader: WARNING: Matching a download by filesize is a fallback mechanism that does not guarantee that a build is unchanged.
URLDownloader: Using existing /Users/paul/Library/AutoPkg/Cache/com.github.n8felton.munki.MAMP/downloads/MAMP_MAMP_PRO_6.8-Intel-x86-6.8.pkg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "MAMP_MAMP_PRO_6.8-Intel-x86-6.8.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2023-01-26 18:17:42 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: MAMP GmbH (5KCB5KHK77)
CodeSignatureVerifier:        Expires: 2024-01-25 09:20:56 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F0 79 14 4F EE 5E 63 2E 38 87 F7 74 0C C9 29 71 F6 4E 28 CC B9 04 
CodeSignatureVerifier:            94 7D 9B EA 20 EF A6 4D 6D E2
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.n8felton.munki.MAMP/downloads/MAMP_MAMP_PRO_6.8-Intel-x86-6.8.pkg to /Users/paul/Library/AutoPkg/Cache/com.github.n8felton.munki.MAMP/unpacked
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.n8felton.munki.MAMP/unpacked/MAMP_PRO.pkg/Payload to /Users/paul/Library/AutoPkg/Cache/com.github.n8felton.munki.MAMP/Applications
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/MAMP PRO.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.12.0
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'de.appsolute.mamppro', 'CFBundleName': 'MAMP PRO', 'CFBundleShortVersionString': '6.8', 'CFBundleVersion': '34110', 'minosversion': '10.12.0', 'path': '/Applications/MAMP PRO.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '10.12.0'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/MAMP/MAMP-6.8__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/MAMP/MAMP_MAMP_PRO_6.8-Intel-x86-6.8.pkg
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.n8felton.munki.MAMP/receipts/MAMP.munki-receipt-20230706-181355.plist

The following new items were imported into Munki:
    Name  Version  Catalogs  Pkginfo Path                 Pkg Repo Path                                  Icon Repo Path  
    ----  -------  --------  ------------                 -------------                                  --------------  
    MAMP  6.8      testing   apps/MAMP/MAMP-6.8__1.plist  apps/MAMP/MAMP_MAMP_PRO_6.8-Intel-x86-6.8.pkg
```