### PR TITLE
Add ARCH support for KeePassXC

### DIFF
--- a/KeePassXC/KeePassXC.download.recipe
+++ b/KeePassXC/KeePassXC.download.recipe
@@ -10,8 +10,10 @@
 	<dict>
 		<key>NAME</key>
 		<string>KeePassXC</string>
+		<key>ARCH</key>
+		<string>x86_64</string> <!-- or arm64-->
 		<key>ASSET_REGEX</key>
-		<string>KeePassXC-.*-x86_64\.dmg</string>
+		<string>KeePassXC-.*-%ARCH%\.dmg</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.0</string>

--- a/KeePassXC/KeePassXC.munki.recipe
+++ b/KeePassXC/KeePassXC.munki.recipe
@@ -14,6 +14,8 @@
 		<string>KeePassXC</string>
 		<key>MUNKI_CATEGORY</key>
 		<string>Utilities</string>
+		<key>SUPPORTED_ARCH</key>
+		<string>x64</string> <!-- or arm64-->
 		<key>pkginfo</key>
 		<dict>
 			<key>catalogs</key>
@@ -50,6 +52,8 @@
 			<string>%MUNKI_CATEGORY%</string>
 			<key>uninstall_method</key>
 			<string>remove_copied_items</string>
+			<key>supported_architectures</key>
+			<string>%SUPPORTED_ARCH%</string>
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>


### PR DESCRIPTION
### Output of `autopkg run -vvvv`
```
{
 'ARCH': 'arm64',
 'ASSET_REGEX': 'KeePassXC-.*-arm64\\.dmg',
 'AUTOPKG_VERSION': '2.7.2',
 'FAIL_RECIPES_WITHOUT_TRUST_INFO': True,
 'NAME': 'KeePassXC',
 'PARENT_RECIPES': [],
 'RECIPE_CACHE_DIR': '/Users/mczack/Library/AutoPkg/Cache/com.github.n8felton.download.KeePassXC',
 'RECIPE_DIR': '/Users/mczack/Library/AutoPkg/RecipeRepos/com.github.autopkg.n8felton-recipes/KeePassXC',
 'RECIPE_OVERRIDE_DIRS': ['Overrides'],
 'RECIPE_PATH': '/Users/mczack/Library/AutoPkg/RecipeRepos/com.github.autopkg.n8felton-recipes/KeePassXC/KeePassXC.download.recipe',
 'verbose': 4}
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'KeePassXC-.*-arm64\\.dmg',
           'github_repo': 'keepassxreboot/keepassxc',
           'include_prereleases': False}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex 'KeePassXC-.*-arm64\.dmg' among asset(s): KeePassXC-2.7.6-arm64.dmg, KeePassXC-2.7.6-arm64.dmg.DIGEST, KeePassXC-2.7.6-arm64.dmg.sig, keepassxc-2.7.6-src.tar.xz, keepassxc-2.7.6-src.tar.xz.DIGEST, keepassxc-2.7.6-src.tar.xz.sig, KeePassXC-2.7.6-Win64-LegacyWindows.msi, KeePassXC-2.7.6-Win64-LegacyWindows.msi.DIGEST, KeePassXC-2.7.6-Win64-LegacyWindows.msi.sig, KeePassXC-2.7.6-Win64-LegacyWindows.zip, KeePassXC-2.7.6-Win64-LegacyWindows.zip.DIGEST, KeePassXC-2.7.6-Win64-LegacyWindows.zip.sig, KeePassXC-2.7.6-Win64.msi, KeePassXC-2.7.6-Win64.msi.DIGEST, KeePassXC-2.7.6-Win64.msi.sig, KeePassXC-2.7.6-Win64.zip, KeePassXC-2.7.6-Win64.zip.DIGEST, KeePassXC-2.7.6-Win64.zip.sig, KeePassXC-2.7.6-x86_64.AppImage, KeePassXC-2.7.6-x86_64.AppImage.DIGEST, KeePassXC-2.7.6-x86_64.AppImage.sig, KeePassXC-2.7.6-x86_64.AppImage.zsync, KeePassXC-2.7.6-x86_64.AppImage.zsync.DIGEST, KeePassXC-2.7.6-x86_64.AppImage.zsync.sig, KeePassXC-2.7.6-x86_64.dmg, KeePassXC-2.7.6-x86_64.dmg.DIGEST, KeePassXC-2.7.6-x86_64.dmg.sig
GitHubReleasesInfoProvider: Selected asset 'KeePassXC-2.7.6-arm64.dmg' from release 'Release 2.7.6'
{'Output': {'asset_created_at': '2023-08-15T23:08:35Z',
            'asset_url': 'https://api.github.com/repos/keepassxreboot/keepassxc/releases/assets/121655435',
            'release_notes': '### Changes\r\n'
                             '- Significant improvement to visual when '
                             'drag/drop entries [#9698]\r\n'
                             '- Automatically prompt for Quick Unlock when '
                             'showing unlock dialog [#9697]\r\n'
                             '- Improve colorful lock icon and fix file MIME '
                             'icon on KDE [#9632]\r\n'
                             '- Ability to search by entry UUID [#9571]\r\n'
                             '- Add challenge-response support for NitroKey 3 '
                             '[#9631]\r\n'
                             '- Auto-Type: Disable entry level Auto-Type when '
                             'disabled at group/entry [#9672]\r\n'
                             '- Browser: Show warning when adding duplicate '
                             "URL's to entry [#9588][#9635]\r\n"
                             '- Browser: Improve error message when proxy '
                             'cannot be found [#9385]\r\n'
                             '\r\n'
                             '### Fixes\r\n'
                             '- Fix crash on exit on macOS [#9620]\r\n'
                             "- Fix crash on search if entry doesn't have a "
                             'group [#9633]\r\n'
                             '- Fix several issues with Quick Unlock '
                             '[#9697]\r\n'
                             '- Enable save button when not auto-saving '
                             'non-data changes [#9634]\r\n'
                             '- Several UI/UX fixes [#9647]\r\n'
                             '- Move toolbar back to top of window when '
                             'disabling movement [#9699]\r\n'
                             '- Browser: Fix handling of expired credentials '
                             '[#9595]\r\n'
                             '- Windows: Prevent white flicker when launching '
                             'application [#9637]\r\n'
                             '- Linux: Fix warning message about allow '
                             'screencapture [#9638]\r\n'
                             '- FdoSecrets: Fix access confirmation dialog '
                             'showing even when disabled [#9690]',
            'url': 'https://github.com/keepassxreboot/keepassxc/releases/download/2.7.6/KeePassXC-2.7.6-arm64.dmg',
            'version': '2.7.6'}}
URLDownloader
{'Input': {'url': 'https://github.com/keepassxreboot/keepassxc/releases/download/2.7.6/KeePassXC-2.7.6-arm64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Curl command: ['/usr/bin/curl', '--silent', '--show-error', '--no-buffer', '--dump-header', '-', '--speed-time', '30', '--location', '--url', 'https://github.com/keepassxreboot/keepassxc/releases/download/2.7.6/KeePassXC-2.7.6-arm64.dmg', '--fail', '--output', '/Users/mczack/Library/AutoPkg/Cache/com.github.n8felton.download.KeePassXC/downloads/tmp77_tv1q_']
URLDownloader: Storing new Last-Modified header: Tue, 15 Aug 2023 23:08:48 GMT
URLDownloader: Storing new ETag header: "0x8DB9DE49520A2D4"
URLDownloader: Downloaded /Users/mczack/Library/AutoPkg/Cache/com.github.n8felton.download.KeePassXC/downloads/KeePassXC-2.7.6-arm64.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8DB9DE49520A2D4"',
            'last_modified': 'Tue, 15 Aug 2023 23:08:48 GMT',
            'pathname': '/Users/mczack/Library/AutoPkg/Cache/com.github.n8felton.download.KeePassXC/downloads/KeePassXC-2.7.6-arm64.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/mczack/Library/AutoPkg/Cache/com.github.n8felton.download.KeePassXC/downloads/KeePassXC-2.7.6-arm64.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/mczack/Library/AutoPkg/Cache/com.github.n8felton.download.KeePassXC/downloads/KeePassXC-2.7.6-arm64.dmg/KeePassXC.app',
           'requirement': 'identifier "org.keepassxc.keepassxc" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'G2S7P7J672'}}
CodeSignatureVerifier: Mounted disk image /Users/mczack/Library/AutoPkg/Cache/com.github.n8felton.download.KeePassXC/downloads/KeePassXC-2.7.6-arm64.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.VgiTO6/KeePassXC.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.VgiTO6/KeePassXC.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.VgiTO6/KeePassXC.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
{ 'ARCH': 'arm64',
 'ASSET_REGEX': 'KeePassXC-.*-arm64\\.dmg',
 'AUTOPKG_VERSION': '2.7.2',
 'CHECK_FILESIZE_ONLY': False,
 'CURL_PATH': '/usr/bin/curl',
 'FAIL_RECIPES_WITHOUT_TRUST_INFO': True,
 'NAME': 'KeePassXC',
 'PARENT_RECIPES': [],
 'RECIPE_CACHE_DIR': '/Users/mczack/Library/AutoPkg/Cache/com.github.n8felton.download.KeePassXC',
 'RECIPE_DIR': '/Users/mczack/Library/AutoPkg/RecipeRepos/com.github.autopkg.n8felton-recipes/KeePassXC',
 'RECIPE_OVERRIDE_DIRS': [                          'Overrides'],
 'RECIPE_PATH': '/Users/mczack/Library/AutoPkg/RecipeRepos/com.github.autopkg.n8felton-recipes/KeePassXC/KeePassXC.download.recipe',
 'RECIPE_REPOS': {},
 'RECIPE_SEARCH_DIRS': [''],
 'asset_created_at': '2023-08-15T23:08:35Z',
 'asset_regex': 'KeePassXC-.*-arm64\\.dmg',
 'asset_url': 'https://api.github.com/repos/keepassxreboot/keepassxc/releases/assets/121655435',
 'download_changed': True,
 'etag': '"0x8DB9DE49520A2D4"',
 'github_repo': 'keepassxreboot/keepassxc',
 'include_prereleases': False,
 'input_path': '/Users/mczack/Library/AutoPkg/Cache/com.github.n8felton.download.KeePassXC/downloads/KeePassXC-2.7.6-arm64.dmg/KeePassXC.app',
 'last_modified': 'Tue, 15 Aug 2023 23:08:48 GMT',
 'pathname': '/Users/mczack/Library/AutoPkg/Cache/com.github.n8felton.download.KeePassXC/downloads/KeePassXC-2.7.6-arm64.dmg',
 'prefetch_filename': False,
 'release_notes': '### Changes\r\n'
                  '- Significant improvement to visual when drag/drop entries '
                  '[#9698]\r\n'
                  '- Automatically prompt for Quick Unlock when showing unlock '
                  'dialog [#9697]\r\n'
                  '- Improve colorful lock icon and fix file MIME icon on KDE '
                  '[#9632]\r\n'
                  '- Ability to search by entry UUID [#9571]\r\n'
                  '- Add challenge-response support for NitroKey 3 [#9631]\r\n'
                  '- Auto-Type: Disable entry level Auto-Type when disabled at '
                  'group/entry [#9672]\r\n'
                  "- Browser: Show warning when adding duplicate URL's to "
                  'entry [#9588][#9635]\r\n'
                  '- Browser: Improve error message when proxy cannot be found '
                  '[#9385]\r\n'
                  '\r\n'
                  '### Fixes\r\n'
                  '- Fix crash on exit on macOS [#9620]\r\n'
                  "- Fix crash on search if entry doesn't have a group "
                  '[#9633]\r\n'
                  '- Fix several issues with Quick Unlock [#9697]\r\n'
                  '- Enable save button when not auto-saving non-data changes '
                  '[#9634]\r\n'
                  '- Several UI/UX fixes [#9647]\r\n'
                  '- Move toolbar back to top of window when disabling '
                  'movement [#9699]\r\n'
                  '- Browser: Fix handling of expired credentials [#9595]\r\n'
                  '- Windows: Prevent white flicker when launching application '
                  '[#9637]\r\n'
                  '- Linux: Fix warning message about allow screencapture '
                  '[#9638]\r\n'
                  '- FdoSecrets: Fix access confirmation dialog showing even '
                  'when disabled [#9690]',
 'requirement': 'identifier "org.keepassxc.keepassxc" and anchor apple generic '
                'and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists '
                '*/ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* '
                'exists */ and certificate leaf[subject.OU] = G2S7P7J672',
 'url': 'https://github.com/keepassxreboot/keepassxc/releases/download/2.7.6/KeePassXC-2.7.6-arm64.dmg',
 'url_downloader_summary_result': {'data': {'download_path': '/Users/mczack/Library/AutoPkg/Cache/com.github.n8felton.download.KeePassXC/downloads/KeePassXC-2.7.6-arm64.dmg'},
                                   'summary_text': 'The following new items '
                                                   'were downloaded:'},
 'verbose': 4,
 'version': '2.7.6'}
Receipt written to /Users/mczack/Library/AutoPkg/Cache/com.github.n8felton.download.KeePassXC/receipts/com.github.n8felton.download-receipt-20231003-133227.plist

The following new items were downloaded:
    Download Path
    -------------
    /Users/mczack/Library/AutoPkg/Cache/com.github.n8felton.download.KeePassXC/downloads/KeePassXC-2.7.6-arm64.dmg
```

Redacted a bunch of things for obvious reasons
