### PR TITLE
fix regex issue with KeePassXC download recipe

### DIFF
--- a/KeePassXC/KeePassXC.download.recipe
+++ b/KeePassXC/KeePassXC.download.recipe
@@ -13,7 +13,7 @@
 		<key>ARCH</key>
 		<string>x86_64</string> <!-- or arm64-->
 		<key>ASSET_REGEX</key>
-		<string>KeePassXC-.*-%ARCH%\.dmg</string>
+		<string>KeePassXC-.*-%ARCH%\.dmg$</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.0</string>


### PR DESCRIPTION
The KeePassXC.download recipe started failing if you use AutoPkg 3.0.0 RC2. Clearly some changes have been made to the `GitHubReleasesInfoProvider` processor that mean regex is handled slightly differently. 

The error is generated by the fact that the processor is downloading a `.dmg.sig` file instead of the `.dmg`:

```
URLDownloader: Downloaded /Users/gpugh/Library/AutoPkg/Cache/com.github.eth-its-recipes.jamf.KeePassXC/downloads/KeePassXC-2.7.6-x86_64.dmg.sig

CodeSignatureVerifier: Error: Error processing path '/Users/gpugh/Library/AutoPkg/Cache/com.github.eth-its-recipes.jamf.KeePassXC/downloads/KeePassXC-2.7.6-x86_64.dmg.sig/KeePassXC.app' with glob
```

This is solved by adding a $ to the end of the regex.

```
GitHubReleasesInfoProvider: Matched regex 'KeePassXC-.*-x86_64\.dmg$' among asset(s): KeePassXC-2.7.6-x86_64.dmg
GitHubReleasesInfoProvider: Selected asset 'KeePassXC-2.7.6-x86_64.dmg' from tag '2.7.6' at url https://github.com/keepassxreboot/keepassxc/releases/download/2.7.6/KeePassXC-2.7.6-x86_64.dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Tue, 15 Aug 2023 23:08:43 GMT
URLDownloader: Storing new ETag header: "0x8DB9DE492128DFC"
URLDownloader: Downloaded /Users/gpugh/Library/AutoPkg/Cache/com.github.n8felton.download.KeePassXC/downloads/KeePassXC-2.7.6-x86_64.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/gpugh/Library/AutoPkg/Cache/com.github.n8felton.download.KeePassXC/downloads/KeePassXC-2.7.6-x86_64.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.2BmY29/KeePassXC.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.2BmY29/KeePassXC.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.2BmY29/KeePassXC.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
```

So this pull request simply adds the $.
