### PR TITLE
Fix orphaned `<dict>` tag

### DIFF
--- a/Yubico/yubioath-desktop.munki.recipe
+++ b/Yubico/yubioath-desktop.munki.recipe
@@ -51,15 +51,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
 			<dict>
-				<key>Processor</key>
-				<string>DeprecationWarning</string>
-				<key>Arguments</key>
-				<dict>
-					<key>warning_message</key>
-					<string>yubioath-desktop has been renamed. Checkout the yubico-authenticator (yubioath-flutter) recipes instead.</string>
-				</dict>
+				<key>warning_message</key>
+				<string>yubioath-desktop has been renamed. Checkout the yubico-authenticator (yubioath-flutter) recipes instead.</string>
 			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>


### PR DESCRIPTION
This PR fixes the orphaned `<dict>` tag that belongs to the `Arguments` child dictionary.

**Before:**

```shell
plutil Yubico/yubioath-desktop.munki.recipe
Yubico/yubioath-desktop.munki.recipe: Found non-key inside <dict> at line 62
```

**After:**
```shell
plutil Yubico/yubioath-desktop.munki.recipe                            
Yubico/yubioath-desktop.munki.recipe: OK
```

**Output of `autopkg run`:**
```shell
autopkg run yubioath-desktop.munki.recipe
Processing yubioath-desktop.munki.recipe...
WARNING: yubioath-desktop.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...

The following recipes have deprecation warnings:
    Name                    Warning                                                                                                   
    ----                    -------                                                                                                   
    yubioath-desktop.munki  yubioath-desktop has been renamed. Checkout the yubico-authenticator (yubioath-flutter) recipes instead.  
    yubioath-desktop.munki  yubioath-desktop has been renamed. Checkout the yubico-authenticator (yubioath-flutter) recipes instead.  

The following new items were imported into Munki:
    Name              Version  Catalogs  Pkginfo Path                            Pkg Repo Path                         Icon Repo Path  
    ----              -------  --------  ------------                            -------------                         --------------  
    yubioath-desktop  4.3      testing   apps/Yubico/yubioath-desktop-4.3.plist  apps/Yubico/yubioath-desktop-4.3.pkg
```
