### PR TITLE
Update BlueJ Recipes

### DIFF
--- a/BlueJ/BlueJ.download.recipe
+++ b/BlueJ/BlueJ.download.recipe
@@ -27,7 +27,7 @@
 				<key>url</key>
 				<string>%DOWNLOAD_URL%</string>
 				<key>re_pattern</key>
-				<string>&lt;a href=&quot;download/files/(BlueJ-mac-\d+[a-z]?\.zip)&quot;&gt;</string>
+				<string>&lt;a href=&quot;download/files/(BlueJ-mac-\d+[a-z]?\.dmg)&quot;&gt;</string>
 			</dict>
 		</dict>
 		<dict>
@@ -46,30 +46,8 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>archive_path</key>
-				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-				<key>purge_destination</key>
-				<true/>
-			</dict>
-			<key>Processor</key>
-			<string>Unarchiver</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pattern</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/*/BlueJ.app</string>
-			</dict>
-			<key>Processor</key>
-			<string>FileFinder</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>input_path</key>
-				<string>%found_filename%</string>
+				<string>%pathname%/BlueJ.app</string>
 				<key>requirement</key>
 				<string>identifier "org.bluej.BlueJ" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5DNSMBAM8L"</string>
 			</dict>
@@ -80,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%found_filename%/Contents/Info.plist</string>
+				<string>%pathname%/BlueJ.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/BlueJ/BlueJ.munki.recipe
+++ b/BlueJ/BlueJ.munki.recipe
@@ -43,28 +43,8 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>pattern</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/*/BlueJ.app</string>
-			</dict>
-			<key>Processor</key>
-			<string>FileFinder</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-				<key>dmg_root</key>
-				<string>%found_filename%</string>
-			</dict>
-			<key>Processor</key>
-			<string>DmgCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>pkg_path</key>
-				<string>%dmg_path%</string>
+				<string>%pathname%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>


### PR DESCRIPTION
Hi, @n8felton 

This PR updates the BlueJ Recipes. 

Download
- Updated regex to search for the DMG file
- Deletion of Unarchiver and  FileFinder steps
- Updated path for Code Signature
- Update path for Versioner

Munki
- Removal of FileFinder and DmgCreator steps
- Updated pkg_path

### Output of `autopkg run -vvvv`
```
autopkg run -v BlueJ.munki.recipe
Looking for com.github.n8felton.download.BlueJ...
Did not find com.github.n8felton.download.BlueJ in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.n8felton.download.BlueJ...
Found com.github.n8felton.download.BlueJ in recipe map
**load_recipe time: 0.0052353329956531525
Processing BlueJ.munki.recipe...
WARNING: BlueJ.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (match): BlueJ-mac-521.dmg
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/paul.cossey/Library/AutoPkg/Cache/com.github.n8felton.munki.BlueJ/downloads/BlueJ-mac-521.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.n8felton.munki.BlueJ/downloads/BlueJ-mac-521.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.BRvGUo/BlueJ.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.BRvGUo/BlueJ.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.BRvGUo/BlueJ.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
Versioner
Versioner: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.n8felton.munki.BlueJ/downloads/BlueJ-mac-521.dmg
Versioner: Found version 5.2.1 in file /Users/paul.cossey/Library/AutoPkg/Cache/com.github.n8felton.munki.BlueJ/downloads/BlueJ-mac-521.dmg/BlueJ.app/Contents/Info.plist
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/BlueJ/BlueJ-5.2.1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/BlueJ/BlueJ-mac-521-5.2.1.dmg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.n8felton.munki.BlueJ/receipts/BlueJ.munki-receipt-20240105-162719.plist

The following new items were imported into Munki:
    Name   Version  Catalogs  Pkginfo Path                  Pkg Repo Path                       Icon Repo Path  
    ----   -------  --------  ------------                  -------------                       --------------  
    BlueJ  5.2.1    testing   apps/BlueJ/BlueJ-5.2.1.plist  apps/BlueJ/BlueJ-mac-521-5.2.1.dmg  
```
