### PR TITLE
[HPPrinterDrivers.download.recipe] Fix for when `PRODUCT_NUMBER` isn't defined

### DIFF
--- a/HPPrinterDrivers/HPPrinterDrivers.download.recipe
+++ b/HPPrinterDrivers/HPPrinterDrivers.download.recipe
@@ -16,6 +16,9 @@
 		<string>HP Color LaserJet Pro M453-4</string>
 		<key>OPERATING_SYSTEM</key>
 		<string>macOS 12.0</string>
+		<key>PRODUCT_NUMBER</key>
+		<!-- For Legacy Support -->
+		<string></string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.4</string>


### PR DESCRIPTION
If `PRODUCT_NUMBER` isn't defined in child recipes, the receipt errors out.

While this value isn't needed and I believe it is only for those that used this recipe before the overhaul, the recipe is still written in a way that it must be defined.

While child recipe can define an empty `PRODUCT_NUMBER`, I think it's more obvious to simply define it in the parent recipe.

Thoughts?


### Output of `autopkg run -vvvv`
**BEFORE**
```
autopkg run com.github.n8felton.download.HPPrinterDrivers --prefs='/Library/AutoPkg/PkgBot/Settings/dev_autopkg_prefs.plist' -vvv 
Processing com.github.n8felton.download.HPPrinterDrivers...
WARNING: com.github.n8felton.download.HPPrinterDrivers is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...

[...]

com.github.n8felton.shared/HPSoftwareInfoProvider
Traceback (most recent call last):
  File "/usr/local/bin/autopkg", line 2786, in <module>
    sys.exit(main(sys.argv))
  File "/usr/local/bin/autopkg", line 2782, in main
    return subcommands[verb]["function"](argv)
  File "/usr/local/bin/autopkg", line 2278, in run_recipes
    autopackager.process(recipe)
  File "/Library/AutoPkg/autopkglib/__init__.py", line 893, in process
    processor.inject(step.get("Arguments", {}))
  File "/Library/AutoPkg/autopkglib/__init__.py", line 673, in inject
    update_data(self.env, key, value)
  File "/Library/AutoPkg/autopkglib/__init__.py", line 518, in update_data
    a_dict[key] = do_variable_substitution(value)
  File "/Library/AutoPkg/autopkglib/__init__.py", line 501, in do_variable_substitution
    item = RE_KEYREF.sub(getdata, item)
  File "/Library/AutoPkg/autopkglib/__init__.py", line 495, in getdata
    return a_dict[match.group("key")]
KeyError: 'PRODUCT_NUMBER'
```


**AFTER**
```
autopkg run com.github.n8felton.download.HPPrinterDrivers --prefs='/Library/AutoPkg/PkgBot/Settings/dev_autopkg_prefs.plist' -vvv 
Processing com.github.n8felton.download.HPPrinterDrivers...
WARNING: com.github.n8felton.download.HPPrinterDrivers is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...

[...]

com.github.n8felton.shared/HPSoftwareInfoProvider
{'Input': {'HP_QUERY': 'HP Color LaserJet Pro M453-4',
           'HP_QUERY_TYPE': 'ModelName',
           'OPERATING_SYSTEM': 'macOS 12.0'}}
HPSoftwareInfoProvider: No value supplied for LANG_CODE, setting default value of: en
HPSoftwareInfoProvider: No value supplied for COUNTRY_CODE, setting default value of: us
HPSoftwareInfoProvider: Software URL: https://h20614.www2.hp.com/ediags/solutions/software/v3?ModelName=HP+Color+LaserJet+Pro+M453-4&OS=macOS%2012.0&lc=en&cc=us&client=hp-quick-start
HPSoftwareInfoProvider: [{'SoftwareId': 'mp-280205-1', 'PID': None, 'ProductNumber': None, 'ModelName': 'HP Color LaserJet Pro M453-4', 'lc': 'en', 'cc': 'us', 'Type': 'ESSENTIAL-REQUIRED', 'Identifier': 'com.hp.pkg.swls.printer-essentials-UniPS.version', 'IdentifierType': 'OSXPackageMakerPackage', 'Version': '6.0.0.6', 'MinVersion': None, 'Function': 'PSF', 'FtpURL': 'ftp://ftp.hp.com/pub/softlib/software12/HP_Quick_Start/osx/Installations/Essentials/macOS12/hp-printer-essentials-UniPS-6_0_0_6.pkg', 'HelpURL': None, 'Title': 'Essential Software', 'Description': 'Installs genuine HP Drivers and HP Utility - essential software for using the features of your HP product.'}, {'SoftwareId': 'mp-300092-1', 'PID': None, 'ProductNumber': None, 'ModelName': 'HP Color LaserJet Pro M453-4', 'lc': 'en', 'cc': 'us', 'Type': 'ESSENTIAL-REQUIRED', 'Identifier': 'com.hp.pkg.swls.printer-essentials-UniPS.version', 'IdentifierType': 'OSXPackageMakerPackage', 'Version': '6.1.0.1', 'MinVersion': None, 'Function': 'PSF', 'FtpURL': 'ftp://ftp.hp.com/pub/softlib/software12/HP_Quick_Start/osx/Installations/Essentials/macOS13/hp-printer-essentials-UniPS-6_1_0_1.pkg', 'HelpURL': None, 'Title': 'Essential Software', 'Description': 'Installs genuine HP Drivers and HP Utility - essential software for using the features of your HP product.'}]
HPSoftwareInfoProvider: https://ftp.hp.com/pub/softlib/software12/HP_Quick_Start/osx/Installations/Essentials/macOS13/hp-printer-essentials-UniPS-6_1_0_1.pkg
{'Output': {'description': 'Installs genuine HP Drivers and HP Utility - '
                           'essential software for using the features of your '
                           'HP product.',
            'url': 'https://ftp.hp.com/pub/softlib/software12/HP_Quick_Start/osx/Installations/Essentials/macOS13/hp-printer-essentials-UniPS-6_1_0_1.pkg',
            'version': '6.1.0.1'}}
URLDownloader
{'Input': {'url': 'https://ftp.hp.com/pub/softlib/software12/HP_Quick_Start/osx/Installations/Essentials/macOS13/hp-printer-essentials-UniPS-6_1_0_1.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False

[...]
```