### PR TITLE
Update "Remote Desktop" to "Windows App"

### DIFF
--- a/Microsoft/Microsoft Remote Desktop Beta.download.recipe
+++ b/Microsoft/Microsoft Remote Desktop Beta.download.recipe
@@ -60,7 +60,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Microsoft Remote Desktop Beta.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Windows App Beta.app</string>
 				<key>requirement</key>
 				<string>identifier "com.microsoft.rdc.osx.beta" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = UBF8T346G9</string>
 			</dict>

--- a/Microsoft/Microsoft Remote Desktop Beta.install.recipe
+++ b/Microsoft/Microsoft Remote Desktop Beta.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>Microsoft Remote Desktop Beta.app</string>
+						<string>Windows App Beta.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Microsoft/Microsoft Remote Desktop Beta.pkg.recipe
+++ b/Microsoft/Microsoft Remote Desktop Beta.pkg.recipe
@@ -23,7 +23,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>app_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Microsoft Remote Desktop Beta.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Windows App Beta.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>AppPkgCreator</string>


### PR DESCRIPTION
This PR updates the name of Microsoft Remote Desktop to [Windows App](https://learn.microsoft.com/en-us/windows-app/overview).
