### PR TITLE
Fix ParaView recipes and add ARCH input variable

### DIFF
--- a/ParaView/ParaView.download.recipe
+++ b/ParaView/ParaView.download.recipe
@@ -10,6 +10,8 @@
 	<dict>
 		<key>NAME</key>
 		<string>ParaView</string>
+		<key>ARCH</key>
+		<string>x86_64</string>
 	</dict>
 	<key>Process</key>
 	<array>
@@ -32,7 +34,7 @@
 				<key>url</key>
 				<string>https://www.paraview.org/files/%folder%/?C=N;O=D</string>
 				<key>re_pattern</key>
-				<string>"(?P&lt;file&gt;ParaView-\d[^"]+64bit\.dmg)</string>
+				<string>"(?P&lt;file&gt;ParaView-[\d\.]+-MPI-OSX[\d\.]+-Python[\d\.]+-%ARCH%.dmg)</string>
 			</dict>
 		</dict>
 		<dict>

--- a/ParaView/ParaView.download.recipe
+++ b/ParaView/ParaView.download.recipe
@@ -3,7 +3,12 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Download recipe for ParaView.</string>
+	<string>Download recipe for ParaView.
+	
+Valid values for ARCH include:
+- "x86_64" (default, Intel)	
+- "arm64" (Apple Silicon)	
+</string>
 	<key>Identifier</key>
 	<string>com.github.n8felton.paraview.download</string>
 	<key>Input</key>


### PR DESCRIPTION
This PR adjusts the file pattern matched by the ParaView download recipe, and adds an ARCH variable that can be used to specify whether to download the Intel or Apple Silicon version of ParaView.

Verbose recipe run output with default (Intel) architecture:

```
% autopkg run -vvq 'ParaView/ParaView.download.recipe'
Processing ParaView/ParaView.download.recipe...
WARNING: ParaView/ParaView.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(?P<folder>v\\d\\.\\d+)\\/',
           'url': 'https://www.paraview.org/files/?C=N;O=D'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (folder): v5.13
URLTextSearcher: Found matching text (match): v5.13
{'Output': {'folder': 'v5.13', 'match': 'v5.13'}}
URLTextSearcher
{'Input': {'re_pattern': '"(?P<file>ParaView-[\\d\\.]+-MPI-OSX[\\d\\.]+-Python[\\d\\.]+-x86_64.dmg)',
           'result_output_var_name': 'match',
           'url': 'https://www.paraview.org/files/v5.13/?C=N;O=D'}}
URLTextSearcher: Found matching text (file): ParaView-5.13.1-MPI-OSX10.15-Python3.10-x86_64.dmg
URLTextSearcher: Found matching text (match): ParaView-5.13.1-MPI-OSX10.15-Python3.10-x86_64.dmg
{'Output': {'file': 'ParaView-5.13.1-MPI-OSX10.15-Python3.10-x86_64.dmg',
            'match': 'ParaView-5.13.1-MPI-OSX10.15-Python3.10-x86_64.dmg'}}
URLDownloader
{'Input': {'filename': 'ParaView.dmg',
           'url': 'https://www.paraview.org/files/v5.13/ParaView-5.13.1-MPI-OSX10.15-Python3.10-x86_64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sat, 28 Sep 2024 01:11:18 GMT
URLDownloader: Storing new ETag header: "1c6e66dd-62323a61cd980"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.n8felton.paraview.download/downloads/ParaView.dmg
{'Output': {'download_changed': True,
            'etag': '"1c6e66dd-62323a61cd980"',
            'last_modified': 'Sat, 28 Sep 2024 01:11:18 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.n8felton.paraview.download/downloads/ParaView.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.n8felton.paraview.download/downloads/ParaView.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.n8felton.paraview.download/downloads/ParaView.dmg/ParaView*.app',
           'requirement': 'identifier "org.paraview.ParaView" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'W38PE5Y733'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.n8felton.paraview.download/downloads/ParaView.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.hNAHxo/ParaView-5.13.1.app' matched from globbed '/private/tmp/dmg.hNAHxo/ParaView*.app'.
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.hNAHxo/ParaView-5.13.1.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.hNAHxo/ParaView-5.13.1.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.hNAHxo/ParaView-5.13.1.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.n8felton.paraview.download/receipts/ParaView.download-receipt-20241227-115557.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.n8felton.paraview.download/downloads/ParaView.dmg
```

Verbose recipe run output with Apple Silicon architecture:

```
% autopkg run -vvq 'ParaView/ParaView.download.recipe' -k ARCH=arm64
Processing ParaView/ParaView.download.recipe...
WARNING: ParaView/ParaView.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(?P<folder>v\\d\\.\\d+)\\/',
           'url': 'https://www.paraview.org/files/?C=N;O=D'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (folder): v5.13
URLTextSearcher: Found matching text (match): v5.13
{'Output': {'folder': 'v5.13', 'match': 'v5.13'}}
URLTextSearcher
{'Input': {'re_pattern': '"(?P<file>ParaView-[\\d\\.]+-MPI-OSX[\\d\\.]+-Python[\\d\\.]+-arm64.dmg)',
           'result_output_var_name': 'match',
           'url': 'https://www.paraview.org/files/v5.13/?C=N;O=D'}}
URLTextSearcher: Found matching text (file): ParaView-5.13.1-MPI-OSX11.0-Python3.10-arm64.dmg
URLTextSearcher: Found matching text (match): ParaView-5.13.1-MPI-OSX11.0-Python3.10-arm64.dmg
{'Output': {'file': 'ParaView-5.13.1-MPI-OSX11.0-Python3.10-arm64.dmg',
            'match': 'ParaView-5.13.1-MPI-OSX11.0-Python3.10-arm64.dmg'}}
URLDownloader
{'Input': {'filename': 'ParaView.dmg',
           'url': 'https://www.paraview.org/files/v5.13/ParaView-5.13.1-MPI-OSX11.0-Python3.10-arm64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sat, 28 Sep 2024 17:04:19 GMT
URLDownloader: Storing new ETag header: "198192e6-62330f65daac0"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.n8felton.paraview.download/downloads/ParaView.dmg
{'Output': {'download_changed': True,
            'etag': '"198192e6-62330f65daac0"',
            'last_modified': 'Sat, 28 Sep 2024 17:04:19 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.n8felton.paraview.download/downloads/ParaView.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.n8felton.paraview.download/downloads/ParaView.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.n8felton.paraview.download/downloads/ParaView.dmg/ParaView*.app',
           'requirement': 'identifier "org.paraview.ParaView" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'W38PE5Y733'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.n8felton.paraview.download/downloads/ParaView.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.W0fVvJ/ParaView-5.13.1.app' matched from globbed '/private/tmp/dmg.W0fVvJ/ParaView*.app'.
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.W0fVvJ/ParaView-5.13.1.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.W0fVvJ/ParaView-5.13.1.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.W0fVvJ/ParaView-5.13.1.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.n8felton.paraview.download/receipts/ParaView.download-receipt-20241227-115802.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.n8felton.paraview.download/downloads/ParaView.dmg
```
