### PR TITLE
Deprecate Intel Unite recipes

### DIFF
--- a/Intel/IntelUnite.download.recipe
+++ b/Intel/IntelUnite.download.recipe
@@ -16,6 +16,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Intel Unite Solution was discontinued on December 31, 2023. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>


### PR DESCRIPTION
This PR deprecates the Intel Unite recipes, since Intel deprecated the Intel Unite Solution in 2023 ([details](https://www.intel.com/content/www/us/en/download/18371/intel-unite-app.html)).
