### PR TITLE
Update BlueJ.download.recipe

### DIFF
--- a/BlueJ/BlueJ.download.recipe
+++ b/BlueJ/BlueJ.download.recipe
@@ -3,13 +3,15 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of BlueJ.</string>
+	<string>Downloads the latest version of BlueJ. Set ARCH to x64 for Intel (default), aarch64 for Apple Silicon/Universal.</string>
 	<key>Identifier</key>
 	<string>com.github.n8felton.download.BlueJ</string>
 	<key>Input</key>
 	<dict>
 		<key>BASE_URL</key>
 		<string>https://www.bluej.org</string>
+		<key>ARCH</key>
+		<string>x64</string>
 		<key>DOWNLOAD_URL</key>
 		<string>%BASE_URL%/versions.html</string>
 		<key>NAME</key>
@@ -27,7 +29,7 @@
 				<key>url</key>
 				<string>%DOWNLOAD_URL%</string>
 				<key>re_pattern</key>
-				<string>&lt;a href=&quot;download/files/(BlueJ-mac-\d+[a-z]?\.dmg)&quot;&gt;</string>
+				<string>&lt;a href=&quot;download/files/(BlueJ-mac-%ARCH%-\d+\.dmg)&quot;&gt;</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Add ARCH consideration

### Output of `autopkg run -vvq`
```
AutoPKGMini ~ % /usr/local/bin/autopkg run -vvq "/Users/Shared/AutoPKGrBin/RecipeRepos/com.github.autopkg.n8felton-recipes/BlueJ/BlueJ.download.recipe"
Processing /Users/Shared/AutoPKGrBin/RecipeRepos/com.github.autopkg.n8felton-recipes/BlueJ/BlueJ.download.recipe...
WARNING: /Users/Shared/AutoPKGrBin/RecipeRepos/com.github.autopkg.n8felton-recipes/BlueJ/BlueJ.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '<a href="download/files/(BlueJ-mac-x64-\\d+\\.dmg)">',
           'url': 'https://www.bluej.org/versions.html'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): BlueJ-mac-x64-541.dmg
{'Output': {'match': 'BlueJ-mac-x64-541.dmg'}}
URLDownloader
{'Input': {'url': 'https://www.bluej.org/download/files/BlueJ-mac-x64-541.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 18 Sep 2024 15:44:02 GMT
URLDownloader: Storing new ETag header: "af104d9-62266acd65480"
URLDownloader: Downloaded /Users/Shared/AutoPKGrBin/Cache/com.github.n8felton.download.BlueJ/downloads/BlueJ-mac-x64-541.dmg
{'Output': {'download_changed': True,
            'etag': '"af104d9-62266acd65480"',
            'last_modified': 'Wed, 18 Sep 2024 15:44:02 GMT',
            'pathname': '/Users/Shared/AutoPKGrBin/Cache/com.github.n8felton.download.BlueJ/downloads/BlueJ-mac-x64-541.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/Shared/AutoPKGrBin/Cache/com.github.n8felton.download.BlueJ/downloads/BlueJ-mac-x64-541.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/Shared/AutoPKGrBin/Cache/com.github.n8felton.download.BlueJ/downloads/BlueJ-mac-x64-541.dmg/BlueJ.app',
           'requirement': 'identifier "org.bluej.BlueJ" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"5DNSMBAM8L"'}}
CodeSignatureVerifier: Mounted disk image /Users/Shared/AutoPKGrBin/Cache/com.github.n8felton.download.BlueJ/downloads/BlueJ-mac-x64-541.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.KVYZSj/BlueJ.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.KVYZSj/BlueJ.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.KVYZSj/BlueJ.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '/Users/Shared/AutoPKGrBin/Cache/com.github.n8felton.download.BlueJ/downloads/BlueJ-mac-x64-541.dmg/BlueJ.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image /Users/Shared/AutoPKGrBin/Cache/com.github.n8felton.download.BlueJ/downloads/BlueJ-mac-x64-541.dmg
Versioner: Found version 5.4.1 in file /Users/Shared/AutoPKGrBin/Cache/com.github.n8felton.download.BlueJ/downloads/BlueJ-mac-x64-541.dmg/BlueJ.app/Contents/Info.plist
{'Output': {'version': '5.4.1'}}
Receipt written to /Users/Shared/AutoPKGrBin/Cache/com.github.n8felton.download.BlueJ/receipts/BlueJ.download-receipt-20250225-110221.plist

The following new items were downloaded:
    Download Path                                                                                       
    -------------                                                                                       
    /Users/Shared/AutoPKGrBin/Cache/com.github.n8felton.download.BlueJ/downloads/BlueJ-mac-x64-541.dmg
```
