### PR TITLE
Add CodeSignatureVerifier processor

### DIFF
--- a/jGrasp/jGrasp.download.recipe
+++ b/jGrasp/jGrasp.download.recipe
@@ -52,6 +52,21 @@
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
 		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%</string>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: Auburn University (73GM27XVPE)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
+			</dict>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This PR adds code signature verification to eligible recipes.

Context: The [CodeSignatureVerifier](https://github.com/autopkg/autopkg/wiki/Using-CodeSignatureVerifier) processor ensures that the downloaded applications/packages are signed by the expected developer certificate. Although this is not a guarantee that the payload is trouble-free, it's a good indicator that the file you downloaded is the one you intended to download.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._