### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/Clustal/ClustalW.download.recipe
+++ b/Clustal/ClustalW.download.recipe
@@ -9,7 +9,7 @@
 	<key>Input</key>
 	<dict>
 		<key>BASE_URL</key>
-		<string>http://www.clustal.org/download/current</string>
+		<string>https://www.clustal.org/download/current</string>
 		<key>NAME</key>
 		<string>ClustalW</string>
 	</dict>

--- a/Clustal/ClustalX.download.recipe
+++ b/Clustal/ClustalX.download.recipe
@@ -9,7 +9,7 @@
 	<key>Input</key>
 	<dict>
 		<key>BASE_URL</key>
-		<string>http://www.clustal.org/download/current</string>
+		<string>https://www.clustal.org/download/current</string>
 		<key>NAME</key>
 		<string>ClustalX</string>
 	</dict>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [in January 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.3.0._