### PR TITLE
fix(GPGSignatureVerifier): defer gpg path lookup to runtime

### DIFF
--- a/SharedProcessors/GPGSignatureVerifier.py
+++ b/SharedProcessors/GPGSignatureVerifier.py
@@ -32,7 +32,6 @@ class GPGSignatureVerifier(Processor):
     input_variables = {
         "gpg_path": {
             "required": False,
-            "default": shutil.which("gpg"),
             "description": "location of the gpg binary",
         },
         "public_key_id": {"required": True, "description": "public key id to import"},
@@ -99,6 +98,8 @@ class GPGSignatureVerifier(Processor):
 
     def main(self) -> None:
         self.env["pathname"] = self.env["distribution_file"]
+        if "gpg_path" not in self.env or not self.env["gpg_path"]:
+            self.env["gpg_path"] = shutil.which("gpg") or ""
         if not self.gpg_found():
             if not self.env.get("PASS_IF_GPG_MISSING", False):
                 raise ProcessorError(


### PR DESCRIPTION
shutil.which("gpg") was evaluated at class definition time, so if gpg was not on PATH when autopkg imported the module the default was baked in as None. This caused a TypeError ("expected str, bytes or os.PathLike object, not NoneType") when the processor ran.

Remove the class-level default and resolve the gpg path at the start of main() instead, falling back to shutil.which("gpg") only when gpg_path is not provided by the caller.

Fixes #250 