### PR TITLE
deprecate(CiscoAMP): mark recipes as deprecated and unmaintained

### DIFF
--- a/CiscoAMP/CiscoAMP.download.recipe
+++ b/CiscoAMP/CiscoAMP.download.recipe
@@ -5,7 +5,9 @@
 	<key>Description</key>
 	<string>Downloads the latest version of Cisco AMP for Endpoints.
 
-DOWNLOAD_URL can be found at https://console.amp.cisco.com/download_connector</string>
+DOWNLOAD_URL can be found at https://console.amp.cisco.com/download_connector
+
+DEPRECATED: This recipe is deprecated and unmaintained. The maintainer no longer uses this product. It may be removed in the future.</string>
 	<key>Identifier</key>
 	<string>com.github.n8felton.download.CiscoAMP</string>
 	<key>Input</key>
@@ -16,9 +18,18 @@ DOWNLOAD_URL can be found at https://console.amp.cisco.com/download_connector</s
 		<string>Cisco AMP</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.0</string>
+	<string>1.1.0</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>This recipe is deprecated and unmaintained. The maintainer no longer uses this product. It may be removed in the future.</string>
+			</dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/CiscoAMP/CiscoAMP.munki.recipe
+++ b/CiscoAMP/CiscoAMP.munki.recipe
@@ -5,7 +5,9 @@
 	<key>Description</key>
 	<string>Downloads the latest version of Cisco AMP for Endpoints and imports it into Munki.
 
-DOWNLOAD_URL can be found at https://console.amp.cisco.com/download_connector</string>
+DOWNLOAD_URL can be found at https://console.amp.cisco.com/download_connector
+
+DEPRECATED: This recipe is deprecated and unmaintained. The maintainer no longer uses this product. It may be removed in the future.</string>
 	<key>Identifier</key>
 	<string>com.github.n8felton.munki.CiscoAMP</string>
 	<key>Input</key>
@@ -39,11 +41,20 @@ DOWNLOAD_URL can be found at https://console.amp.cisco.com/download_connector</s
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.0</string>
+	<string>1.1.0</string>
 	<key>ParentRecipe</key>
 	<string>com.github.n8felton.download.CiscoAMP</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>This recipe is deprecated and unmaintained. The maintainer no longer uses this product. It may be removed in the future.</string>
+			</dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
The maintainer no longer uses Cisco AMP and cannot fully test changes. Adds DeprecationWarning as the first processor in both recipes and updates MinimumVersion to 1.1.0 to match the processor requirement.

Closes #100 