### PR TITLE
deprecate(Neo4j-CE): mark recipes deprecated in favor of dataJAR Neo4j Desktop

### DIFF
--- a/Neo4j/Neo4j-CE.download.recipe
+++ b/Neo4j/Neo4j-CE.download.recipe
@@ -3,7 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Download recipe for Neo4j Community Edition.</string>
+	<string>Download recipe for Neo4j Community Edition.
+
+DEPRECATED: This recipe is deprecated and unmaintained. Neo4j Community Edition is no longer distributed as a macOS app. Use the Neo4j Desktop recipes in autopkg/dataJAR-recipes instead. It may be removed in the future.</string>
 	<key>Identifier</key>
 	<string>com.github.n8felton.neo4j-ce.download</string>
 	<key>Input</key>
@@ -12,9 +14,18 @@
 		<string>Neo4j-CE</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.9</string>
+	<string>1.1.0</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>This recipe is deprecated and unmaintained. Neo4j Community Edition is no longer distributed as a macOS app. Use the Neo4j Desktop recipes in autopkg/dataJAR-recipes instead. It may be removed in the future.</string>
+			</dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/Neo4j/Neo4j-CE.munki.recipe
+++ b/Neo4j/Neo4j-CE.munki.recipe
@@ -3,7 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of Neo4j Community Edition and imports it into Munki.</string>
+	<string>Downloads the latest version of Neo4j Community Edition and imports it into Munki.
+
+DEPRECATED: This recipe is deprecated and unmaintained. Neo4j Community Edition is no longer distributed as a macOS app. Use the Neo4j Desktop recipes in autopkg/dataJAR-recipes instead. It may be removed in the future.</string>
 	<key>Identifier</key>
 	<string>com.github.n8felton.neo4j-ce.munki</string>
 	<key>Input</key>
@@ -34,11 +36,20 @@ Default login is username &lt;strong&gt;'neo4j'&lt;/strong&gt; and password &lt;
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.9</string>
+	<string>1.1.0</string>
 	<key>ParentRecipe</key>
 	<string>com.github.n8felton.neo4j-ce.download</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>This recipe is deprecated and unmaintained. Neo4j Community Edition is no longer distributed as a macOS app. Use the Neo4j Desktop recipes in autopkg/dataJAR-recipes instead. It may be removed in the future.</string>
+			</dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
The original Neo4j-CE download flow (neo4j.com/artifact.php CloudFront .dmg) is gone. As of 2026, Neo4j Community Edition on Mac is a Java server tarball, not a macOS app. The autopkg/dataJAR-recipes repo maintains Neo4j Desktop recipes (com.github.dataJAR-recipes.download.Neo4j Desktop and Neo4j Desktop 2) which cover the GUI product.

Closes #97
