### PR TITLE
fix(Geneious): fix download for modern versions using FindAndReplace

### DIFF
--- a/Geneious/Geneious.download.recipe
+++ b/Geneious/Geneious.download.recipe
@@ -23,7 +23,7 @@ See http://desktop-links.geneious.com/assets/installers/geneious/GeneiousVersion
 		<string>https://desktop-links.geneious.com/assets/installers/geneious/GeneiousVersions.txt</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.3.1</string>
+	<string>2.7.6</string>
 	<key>Process</key>
 	<array>
 		<dict>
@@ -36,6 +36,21 @@ See http://desktop-links.geneious.com/assets/installers/geneious/GeneiousVersion
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>find</key>
+				<string>-</string>
+				<key>input_string</key>
+				<string>%match%</string>
+				<key>replace</key>
+				<string>_</string>
+				<key>result_output_var_name</key>
+				<string>match</string>
+			</dict>
+			<key>Processor</key>
+			<string>FindAndReplace</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>
@@ -54,7 +69,7 @@ See http://desktop-links.geneious.com/assets/installers/geneious/GeneiousVersion
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/Geneious.app</string>
+				<string>%pathname%/Geneious*.app</string>
 				<key>requirement</key>
 				<string>identifier "com.biomatters.Geneious" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "3BTDDQD3L6"</string>
 			</dict>


### PR DESCRIPTION
## Summary

- Geneious lists filenames in `GeneiousVersions.txt` with a dash (`Geneious_Prime-mac64_...`) but the actual download URL requires an underscore (`Geneious_Prime_mac64_...`) — the dash form returns HTTP 403, the underscore form returns HTTP 200. This has been the case since at least 2019 and still affects the current 2026 release line.
- Adds a `FindAndReplace` step (core AutoPkg processor, introduced in 2.7.6) between `URLTextSearcher` and `URLDownloader` to rewrite `%match%` in-place before the URL is constructed.
- Updates `CodeSignatureVerifier` `input_path` from `Geneious.app` to `Geneious*.app` to match the current app bundle name (`Geneious Prime.app`).
- Bumps `MinimumVersion` to `2.7.6` to require `FindAndReplace` support.

Supersedes #96 and #128.

## Test plan

- [x] Verified `GeneiousVersions.txt` dash-form URL → HTTP 403; underscore-form URL → HTTP 200
- [x] `autopkg run -vv .../Geneious.download.recipe -k MAJOR_VERSION=2026` completes successfully: `URLTextSearcher` matches, `FindAndReplace` rewrites, `URLDownloader` downloads, `CodeSignatureVerifier` validates `Geneious Prime.app` against Team ID `3BTDDQD3L6`