### PR TITLE
Revert "Update Bruno.download.recipe - Code Signature"

### DIFF
--- a/Bruno/Bruno.download.recipe
+++ b/Bruno/Bruno.download.recipe
@@ -53,7 +53,7 @@ ARCH_TYPE=("arm64", "x64")</string>
 				<key>input_path</key>
 				<string>%pathname%/Bruno.app</string>
 				<key>requirement</key>
-				<string>identifier "com.usebruno.app" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = P3WTZH48ZB</string>
+				<string>identifier "com.usebruno.app" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = W7LPPWA48L</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
Reverts autopkg/n8felton-recipes#266

They do not address why they've made and then reverted the change, but that's how it stands.

From https://github.com/usebruno/bruno/releases/tag/v3.5.2:
Changelog
Maintenance
Reverted signing identity to Anoop MD
Added chain of trust (designated requirement) for the apple signing certificates.